### PR TITLE
OP tools Python3 fixes

### DIFF
--- a/web/staff/op_tools/accounts.py
+++ b/web/staff/op_tools/accounts.py
@@ -14,7 +14,7 @@ def print_results(results,order=None):
         print('<td><b><a href="accounts_daily.py?year=%d&month=%d">%s</a></b></td>' % (date.year,date.month,date.strftime('%Y-%m')))
         if order != None:
             for o in order:
-                if row.has_key(o):
+                if o in row:
                     print('<td>%s</td>' % (row[o]))
                 else:
                     print('<td>0</td>')

--- a/web/staff/op_tools/accounts.py
+++ b/web/staff/op_tools/accounts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # account.py
 # Patrick McQuighan
 # Replacement for catalog.pl written in Python and using the new database as of 11/2010
@@ -10,29 +10,29 @@ def print_results(results,order=None):
     corresponding to the payment type'''
     for date in sorted(results.keys()):
         row = results[date]
-        print '<tr>'
-        print '<td><b><a href="accounts_daily.py?year=%d&month=%d">%s</a></b></td>' % (date.year,date.month,date.strftime('%Y-%m'))
+        print('<tr>')
+        print('<td><b><a href="accounts_daily.py?year=%d&month=%d">%s</a></b></td>' % (date.year,date.month,date.strftime('%Y-%m')))
         if order != None:
             for o in order:
                 if row.has_key(o):
-                    print '<td>%s</td>' % (row[o])
+                    print('<td>%s</td>' % (row[o]))
                 else:
-                    print '<td>0</td>'
+                    print('<td>0</td>')
         else:
-            print '<td>%s</td>' % (row)
-        print '</tr>'
+            print('<td>%s</td>' % (row))
+        print('</tr>')
 
-print 'Content-Type: text/html\n'
-print '''<html>
+print('Content-Type: text/html\n')
+print('''<html>
  <head>
     <title>OP Monthly Accounts</title>
 
 </head>
- <body>'''
+ <body>''')
 
 sales,payments,cash = db.get_accounts('monthly')
 
-print '''
+print('''
 <table border='1'> <caption>Total Sales</caption>
  <thead>
  <tr>
@@ -46,15 +46,15 @@ print '''
  </tr>
 </thead>
 
-<tbody>'''
+<tbody>''')
 print_results(sales, ['cash','check','debit/credit','tab','link','total'])
-print '''
+print('''
 </tbody>
 
 </table>
-'''
+''')
 
-print '''
+print('''
 <table border='1'> <caption>Tab Payments</caption>
 <thead>
  <tr>
@@ -66,15 +66,15 @@ print '''
  </tr>
 </thead>
 
-<tbody>'''
+<tbody>''')
 print_results(payments, ['cash','check','debit/credit','link'])
 
-print'''
+print('''
 </tbody>
 
-</table>'''
+</table>''')
 
-print '''
+print('''
 <table border='1'> <caption>Total Cash In (including tab payments)</caption>
 <thead>
  <tr>
@@ -83,11 +83,11 @@ print '''
  </tr>
 </thead>
 
-<tbody>'''
+<tbody>''')
 print_results(cash)
-print '''
+print('''
 </tbody>
 
-</table>'''
+</table>''')
 
-print '</body></html>'
+print('</body></html>')

--- a/web/staff/op_tools/accounts_daily.py
+++ b/web/staff/op_tools/accounts_daily.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # account.py
 # Patrick McQuighan
 # Replacement for catalog.pl written in Python and using the new database as of 11/2010
@@ -13,17 +13,17 @@ def print_results(results,order=None):
     corresponding to the payment type'''
     for date in sorted(results.keys()):
         row = results[date]
-        print '<tr>'
-        print '<td><b>%s</b></td>' % (date.strftime('%Y-%m-%d'))
+        print('<tr>')
+        print('<td><b>%s</b></td>' % (date.strftime('%Y-%m-%d')))
         if order != None:
             for o in order:
                 if row.has_key(o):
-                    print '<td>%s</td>' % (row[o])
+                    print('<td>%s</td>' % (row[o]))
                 else:
-                    print '<td>0</td>'
+                    print('<td>0</td>')
         else:
-            print '<td>%s</td>' % (row)
-        print '</tr>'
+            print('<td>%s</td>' % (row))
+        print('</tr>')
 
 def print_body(month,year):
     start = datetime.datetime(year,month,1)
@@ -33,8 +33,8 @@ def print_body(month,year):
         end = datetime.datetime(year+1,1,1)
 
     sales,payments,cash = db.get_accounts('daily',start,end)
-    
-    print '''
+
+    print('''
 <table border='1'> <caption>Total Sales</caption>
  <thead>
  <tr>
@@ -48,14 +48,14 @@ def print_body(month,year):
  </tr>
 </thead>
 
-<tbody>'''
+<tbody>''')
     print_results(sales, ['cash','check','debit/credit','tab','link','total'])
-    print '''
+    print('''
 </tbody>
 
 </table>
-'''
-    print '''
+''')
+    print('''
 <table border='1'> <caption>Tab Payments</caption>
 <thead>
  <tr>
@@ -67,15 +67,15 @@ def print_body(month,year):
  </tr>
 </thead>
 
-<tbody>'''
+<tbody>''')
     print_results(payments, ['cash','check','debit/credit','link'])
-    
-    print '''
+
+    print('''
 </tbody>
 
-</table>'''
+</table>''')
 
-    print '''
+    print('''
 <table border='1'> <caption>Total Cash In (including tab payments)</caption>
 <thead>
  <tr>
@@ -84,26 +84,26 @@ def print_body(month,year):
  </tr>
 </thead>
 
-<tbody>'''
+<tbody>''')
     print_results(cash)
-    print '''
+    print('''
 </tbody>
 
-</table>'''
-    
+</table>''')
 
 
-print 'Content-Type: text/html\n'
-print '''<html>
+
+print('Content-Type: text/html\n')
+print('''<html>
  <head>
     <title>OP Daily Accounts</title>
 
 </head>
- <body>'''
+ <body>''')
 form = cgi.FieldStorage()
 if not form.has_key('month') or not form.has_key('year'):
-    print 'Error! You must include a year and a month. Please go through <a href="accounts.py"> this tool</a>'
+    print('Error! You must include a year and a month. Please go through <a href="accounts.py"> this tool</a>')
 else:
     print_body(int(form.getvalue('month')), int(form.getvalue('year')))
 
-print '</body></html>'
+print('</body></html>')

--- a/web/staff/op_tools/accounts_daily.py
+++ b/web/staff/op_tools/accounts_daily.py
@@ -17,7 +17,7 @@ def print_results(results,order=None):
         print('<td><b>%s</b></td>' % (date.strftime('%Y-%m-%d')))
         if order != None:
             for o in order:
-                if row.has_key(o):
+                if o in row:
                     print('<td>%s</td>' % (row[o]))
                 else:
                     print('<td>0</td>')
@@ -101,7 +101,7 @@ print('''<html>
 </head>
  <body>''')
 form = cgi.FieldStorage()
-if not form.has_key('month') or not form.has_key('year'):
+if 'month' not in form or 'year' not in form:
     print('Error! You must include a year and a month. Please go through <a href="accounts.py"> this tool</a>')
 else:
     print_body(int(form.getvalue('month')), int(form.getvalue('year')))

--- a/web/staff/op_tools/add_items.py
+++ b/web/staff/op_tools/add_items.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # add_items.py
 # Patrick McQuighan
 # quick thing enabling adding items to the database
@@ -9,14 +9,14 @@ import cgi
 import cgitb
 cgitb.enable()
 
-print '''Content-Type: text/html\n\n'''
-print '''<html><head>
+print('''Content-Type: text/html\n\n''')
+print('''<html><head>
     <title>Open Produce Add Items Page</title>
     <style type="text/css">
     * { font-size: 12px; }\n
     </style>
     </head>
-    <body>'''
+    <body>''')
 form = cgi.FieldStorage()
 if "name" in form  and "taxcat" in form and ("price" in form and "price_unit" in form or "price_id" in form) and "count" in form and "itemsize" in form and "size_unit" in form:
     name = form.getvalue('name')
@@ -32,9 +32,9 @@ if "name" in form  and "taxcat" in form and ("price" in form and "price_unit" in
         else:
             price = p_id
             price_unit = None
-    
+
     if not_valid:
-        print '<br /> Invalid price_id'
+        print('<br /> Invalid price_id')
     else:
         count = int(form.getvalue('count'))
         plu = None
@@ -69,48 +69,48 @@ if "name" in form  and "taxcat" in form and ("price" in form and "price_unit" in
 
                 case_unitid = db.get_unit_byname(case_unit).get_id()
                 db.update_distributor_item(d_i,ditemid, wholesale_price, case_size, case_unitid)
-                print '<br />Included distributor info'
+                print('<br />Included distributor info')
             else:
-                print '<br />No valid distributor name entered, distributor info ignored'
-        
-        print '<br />Successfully added "%s" as item id %d' % (name, itemid)
+                print('<br />No valid distributor name entered, distributor info ignored')
+
+        print('<br />Successfully added "%s" as item id %d' % (name, itemid))
 else:
-    print '''<p>Not all required fields were filled out </p>'''
+    print('''<p>Not all required fields were filled out </p>''')
 
-print '''<form name="newitem" action="add_items.py" method="get">'''
-print '''item name*: <input type="text" name="name" />'''
-print '''item size*: <input type="text" name="itemsize" size="5" /> size unit*: <select name="size_unit">'''
+print('''<form name="newitem" action="add_items.py" method="get">''')
+print('''item name*: <input type="text" name="name" />''')
+print('''item size*: <input type="text" name="itemsize" size="5" /> size unit*: <select name="size_unit">''')
 for unit in db.get_units():
-    print '''<option> %s </option> ''' % unit
-print '''</select>'''
-print '''barcode: <input type="text" name="barcode" size="10" />'''
-print '''PLU : <input type="text" name="plu" size="10" />'''
-print '''count*: <input type="text" name="count" size="3" /> <br />'''
-print '''price: $<input type="text" name="price" size="5"/>'''
-print '''price unit: <select name="price_unit">'''
+    print('''<option> %s </option> ''' % unit)
+print('''</select>''')
+print('''barcode: <input type="text" name="barcode" size="10" />''')
+print('''PLU : <input type="text" name="plu" size="10" />''')
+print('''count*: <input type="text" name="count" size="3" /> <br />''')
+print('''price: $<input type="text" name="price" size="5"/>''')
+print('''price unit: <select name="price_unit">''')
 for unit in db.get_units():
-    print '''<option> %s </option> ''' % unit
-print '''</select>'''
-print '''price id: <input type="text" name="price_id" size="4" />'''
-print '''tax category*: <select name="taxcat">'''
+    print('''<option> %s </option> ''' % unit)
+print('''</select>''')
+print('''price id: <input type="text" name="price_id" size="4" />''')
+print('''tax category*: <select name="taxcat">''')
 for taxcat in db.get_tax_categories():
-    print '''<option> %s </option> ''' % taxcat
-print '''</select> <br />'''
+    print('''<option> %s </option> ''' % taxcat)
+print('''</select> <br />''')
 
-print '''distributor: <select name="distributor" /> '''
-print '''<option></option>'''
+print('''distributor: <select name="distributor" /> ''')
+print('''<option></option>''')
 for dist in db.get_distributors():
-    print '''<option> %s </option> ''' % dist
-print '''</select>'''
-print '''distributor item id: <input type="text" name="dist_item_id" size=10" /> '''
-print '''case price: <input type="text" name="wholesale_price" size="5" /> '''
-print '''case size: <input type="text" name="case_size" size=5" /> '''
-print '''case unit: <select name="case_unit"> '''
-for unit in db.get_units():           
-    print '''<option> %s </option> ''' % unit
-print '''</select> <br />'''
+    print('''<option> %s </option> ''' % dist)
+print('''</select>''')
+print('''distributor item id: <input type="text" name="dist_item_id" size=10" /> ''')
+print('''case price: <input type="text" name="wholesale_price" size="5" /> ''')
+print('''case size: <input type="text" name="case_size" size=5" /> ''')
+print('''case unit: <select name="case_unit"> ''')
+for unit in db.get_units():
+    print('''<option> %s </option> ''' % unit)
+print('''</select> <br />''')
 
-print ''' <input type="submit" value="Add Item" /> </form>'''
-print '''Starred fields are required <br />'''
-print '''Input either a price AND a price unit OR a price id'''
-print '''</body></html>'''
+print(''' <input type="submit" value="Add Item" /> </form>''')
+print('''Starred fields are required <br />''')
+print('''Input either a price AND a price unit OR a price id''')
+print('''</body></html>''')

--- a/web/staff/op_tools/add_items_js.py
+++ b/web/staff/op_tools/add_items_js.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # add_items_js.py
 # Patrick McQuighan
 # edited add_items.py to be at the top of manage_prices
@@ -10,26 +10,26 @@ import cgi
 import cgitb
 cgitb.enable()
 
-print '''Content-Type: text/html\n\n'''
-print '''<html><head>
+print('''Content-Type: text/html\n\n''')
+print('''<html><head>
     <title>Open Produce Add Items Page</title>
     <style type="text/css">
     * { font-size: 12px; }\n
     </style>
     <script type="text/javascript" src="../../common/jquery-1.3.2.min.js"></script>
     <script type="text/javascript">
-'''
+''')
 # The following array is needed so that the when an item is split it will have the dropdown to change sale units
-print '''units = new Array();'''
+print('''units = new Array();''')
 for i,unit in enumerate(db.get_units()):
-    print '''units[%d] = '%s';''' % (i, str(unit))
+    print('''units[%d] = '%s';''' % (i, str(unit)))
 # The following is just to remove whitespace and &nbsp's from stuff
-print '''
+print('''
     function trim(str) {
        return str.replace(/^[\s]+/g,'').replace(/[\s]+$/g,'');
-    }'''
+    }''')
 
-print '''
+print('''
     function addItem(){
        name = $('#name').val();
        size = $('#itemsize').val();
@@ -44,7 +44,7 @@ print '''
 
        var categories = '';
        catselect = $('#categories option:selected').each(function() {
-                categories += $(this).val(); 
+                categories += $(this).val();
                 categories += ',';
        });
 
@@ -113,7 +113,7 @@ print '''
                $('.group', window.parent.main.document).keypress(parent.main.handleGroupChange);
                $('.amt', window.parent.main.document).keypress(parent.main.handleAmtChange);
 
- 
+
                $('#name').val('');
                $('#itemsize').val('');
                $('#barcode').val('');
@@ -124,7 +124,7 @@ print '''
                $('#wholesale_price').val('');
                $('#case_size').val('');
                $('#price').val('');
-              
+
                 parent.main.updateMargins(price_id);
             }
             else{
@@ -134,54 +134,54 @@ print '''
 };
     </script>
     </head>
-    <body>'''
+    <body>''')
 
 
 
 
-print '''item name*: <input type="text" id="name" />'''
-print '''item size*: <input type="text" id="itemsize" size="5" /> size unit*: <select id="size_unit">'''
+print('''item name*: <input type="text" id="name" />''')
+print('''item size*: <input type="text" id="itemsize" size="5" /> size unit*: <select id="size_unit">''')
 for unit in db.get_units():
-    print '''<option> %s </option> ''' % unit
-print '''</select>'''
-print '''barcode: <input type="text" id="barcode" size="10" />'''
-print '''PLU : <input type="text" id="plu" size="10" />'''
-print '''count*: <input type="text" id="count" size="3" /> <br />'''
-print '''price: $<input type="text" id="price" size="5"/>'''
-print '''price unit: <select id="price_unit">'''
+    print('''<option> %s </option> ''' % unit)
+print('''</select>''')
+print('''barcode: <input type="text" id="barcode" size="10" />''')
+print('''PLU : <input type="text" id="plu" size="10" />''')
+print('''count*: <input type="text" id="count" size="3" /> <br />''')
+print('''price: $<input type="text" id="price" size="5"/>''')
+print('''price unit: <select id="price_unit">''')
 for unit in db.get_units():
-    print '''<option> %s </option> ''' % unit
-print '''</select>'''
-print '''price id: <input type="text" id="price_id" size="4" />'''
-print '''tax category*: <select id="taxcat">'''
+    print('''<option> %s </option> ''' % unit)
+print('''</select>''')
+print('''price id: <input type="text" id="price_id" size="4" />''')
+print('''tax category*: <select id="taxcat">''')
 for taxcat in db.get_tax_categories():
     isdefault = ''
     if taxcat.get_name() == 'food':
         isdefault = 'selected'
-    print '''<option %s> %s </option> ''' % (isdefault,taxcat)
-print '''</select> <br />'''
+    print('''<option %s> %s </option> ''' % (isdefault,taxcat))
+print('''</select> <br />''')
 
-print '''distributor*: <select id="distributor" /> '''
-print '''<option></option>'''
+print('''distributor*: <select id="distributor" /> ''')
+print('''<option></option>''')
 for dist in db.get_distributors():
-    print '''<option> %s </option> ''' % dist
-print '''</select>'''
+    print('''<option> %s </option> ''' % dist)
+print('''</select>''')
 
-print '''distributor item id: <input type="text" id="dist_item_id" size=10" /> '''
-print '''case price: <input type="text" id="wholesale_price" size="5" /> '''
-print '''case size: <input type="text" id="case_size" size=5" /> '''
+print('''distributor item id: <input type="text" id="dist_item_id" size=10" /> ''')
+print('''case price: <input type="text" id="wholesale_price" size="5" /> ''')
+print('''case size: <input type="text" id="case_size" size=5" /> ''')
 
-print '''case unit: <select id="case_unit"> '''
-for unit in db.get_units():           
-    print '''<option> %s </option> ''' % unit
-print '''</select> <br />'''
+print('''case unit: <select id="case_unit"> ''')
+for unit in db.get_units():
+    print('''<option> %s </option> ''' % unit)
+print('''</select> <br />''')
 
-print '''categories: <select multiple size=5 id="categories">'''
+print('''categories: <select multiple size=5 id="categories">''')
 for cat in db.get_categories():
-    print '''<option value="%d"> %s </option>''' % (cat.get_id(),cat)
-print '''</select> <br />'''
+    print('''<option value="%d"> %s </option>''' % (cat.get_id(),cat))
+print('''</select> <br />''')
 
-print ''' <input type="button" value="Add Item" onClick="addItem()"/>'''
-print '''Starred fields are required <br />'''
-print '''Input either a price AND a price unit OR a price id'''
-print '''</body></html>'''
+print(''' <input type="button" value="Add Item" onClick="addItem()"/>''')
+print('''Starred fields are required <br />''')
+print('''Input either a price AND a price unit OR a price id''')
+print('''</body></html>''')

--- a/web/staff/op_tools/autocount_items.py
+++ b/web/staff/op_tools/autocount_items.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # autocount_items.py
 # Patrick McQuighan
 # This script should be run periodically when the store is not open to perform an auto-update of the last_count and last_count_timestamp

--- a/web/staff/op_tools/catalog.py
+++ b/web/staff/op_tools/catalog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # catalog.py
 # Patrick McQuighan
 # Replacement for catalog.pl written in Python and using the new database as of 11/2010
@@ -15,8 +15,8 @@ cgitb.enable()
 spec_date_format = "%A %m/%d/%y"
 
 def print_headers():
-    print '''Content-Type: text/html\n\n'''
-    print '''<html><head>
+    print('''Content-Type: text/html\n\n''')
+    print('''<html><head>
     <title>Open Produce Catalog</title>
 
     <link rel="stylesheet" type="text/css" href="../../common/tools.css" />
@@ -75,14 +75,14 @@ $(document).ready(function() {
 });
 
 </script>
-'''
+''')
     idf.print_javascript()
-    print '''
-    </head>'''
+    print('''
+    </head>''')
 
 def print_dates(days,selected_date):
     today = datetime.datetime.now()
-    print '''<select id="exp_date" name="exp_date">'''
+    print('''<select id="exp_date" name="exp_date">''')
 
     for i in range(days):
         day = today + datetime.timedelta(days=i)
@@ -91,14 +91,14 @@ def print_dates(days,selected_date):
         else:
             selected = ""
         d_string = day.strftime(spec_date_format)
-        print '''<option value='%s' %s> %s </option>''' % (d_string, selected, d_string)
-    print '''</select>'''
+        print('''<option value='%s' %s> %s </option>''' % (d_string, selected, d_string))
+    print('''</select>''')
 
 def main():
     form = cgi.FieldStorage()
     idf.init(form,discontinued=True,distributors=True,categories=True)
     print_headers()
-    print '''
+    print('''
 <body>
 <div class="key">
          Key:
@@ -114,12 +114,12 @@ def main():
          <div>The Out in column estimates the number of days of stock left in store.  It uses the average # units sold per day for the last 14 days to get its estimate</div>
          <div>The Spec column shows the estimated stock count for 'Speculate stock for date:' day.  Speculation is based on average # units sold per day for the last 14 days. The default date is for the next Thursday</div>
          <div>The New count field is meant to change an item's count after doing a manual count.  Deliveries should be logged under manage_prices.  Type a new count and press ENTER </div>
-         <div style="clear: both; height: 15px;"> </div>'''
-    
-    print '''<form name="options" action="catalog.py" method="get">'''
+         <div style="clear: both; height: 15px;"> </div>''')
+
+    print('''<form name="options" action="catalog.py" method="get">''')
     options = idf.print_form()    # prints out all of the options for item displaying
 
-    print '''Speculate stock for date'''
+    print('''Speculate stock for date''')
     if "exp_date" in form:
         speculate_date = datetime.datetime.strptime(form.getvalue("exp_date"), spec_date_format)
         days_to_speculate = (speculate_date - datetime.datetime.now()).days
@@ -128,9 +128,9 @@ def main():
         today = datetime.datetime.now()
         days_to_speculate = (6 - today.weekday() + 4) % 7  # weekday goes Monday=0, Sunday=6 so: 6-today = days to next sunday
         print_dates(14, today+datetime.timedelta(days=days_to_speculate))
-    print ''' <br /><input type="submit" value="Change options" /> </form>'''
-    print '''<br /><br />'''
-    print '''<table border=0 class="sortable" cellspacing=2 cellpadding=0>
+    print(''' <br /><input type="submit" value="Change options" /> </form>''')
+    print('''<br /><br />''')
+    print('''<table border=0 class="sortable" cellspacing=2 cellpadding=0>
              <thead class="col-header"><tr>
              <th class="th">dist (case size/units/price)</th>
              <th class="th">d item id</th>
@@ -147,7 +147,7 @@ def main():
              <th class="th">OP SKU</th>
              <th class="th">barcodes</th>
              <th class="th">Stocked</th>
-             </thead><tbody id="item-stats">\n'''
+             </thead><tbody id="item-stats">\n''')
 
     distributors = dict([(d.get_id(), d) for d in db.get_distributors()])
     for item in db.get_items(**options):
@@ -156,10 +156,10 @@ def main():
         item_id = item.get_id()
         day7, day14, day30 = db.get_sales_in_multi_range(item_id,7,14,30)
         stock_strings = ['%.2f'%day7,'%.2f'%day14,'%.2f'%day30]
-        dist_list = item.get_distributors()     
+        dist_list = item.get_distributors()
         dist_count = len(dist_list)
-        
-        for i in range(max(1,dist_count)):   # need the max in case the item has no distributors            
+
+        for i in range(max(1,dist_count)):   # need the max in case the item has no distributors
             row_color = ""
             if count < -10.0:
                 row_color = "na"
@@ -169,48 +169,48 @@ def main():
                 row_color = "out"
             elif count < day14:
                 row_color = "low"
-            print '<tr id="tr_%d_%.2f" class="%s">' % (item_id, day14,row_color)
-            
-            print '<div class="div_%d">' % (item_id)
-        
+            print('<tr id="tr_%d_%.2f" class="%s">' % (item_id, day14,row_color))
+
+            print('<div class="div_%d">' % (item_id))
+
             if dist_count == 0:  # don't have any distributors so we just print blanks in first two spots
-                print '''<td> - &nbsp; </td> <td> - &nbsp; </td>'''
+                print('''<td> - &nbsp; </td> <td> - &nbsp; </td>''')
             else:
                 d_i = dist_list[i]
                 dist = distributors[d_i.get_dist_id()]
                 case_str = '''%.2f''' % d_i.get_case_size()
                 price_str = '''$%.2f''' % d_i.get_wholesale_price()
-                print '''<td>''',str(dist),'(',case_str,' ',d_i.get_case_unit(),' ',price_str,') </td> <td>',d_i.get_dist_item_id(),' </td>'''
-        
-            print '''<td style='padding-left: 1em;'>''',str(item),'</td>'''
-            print '''<td>''',item.get_size_str(),'''</td>'''
-            print '''<td>''',item.get_price_str(),'''</td>'''
-            print '<td>',stock_strings[0],'</td><td>',stock_strings[1],'</td><td>',stock_strings[2],'</td>'
+                print('''<td>''',str(dist),'(',case_str,' ',d_i.get_case_unit(),' ',price_str,') </td> <td>',d_i.get_dist_item_id(),' </td>''')
+
+            print('''<td style='padding-left: 1em;'>''',str(item),'</td>''')
+            print('''<td>''',item.get_size_str(),'''</td>''')
+            print('''<td>''',item.get_price_str(),'''</td>''')
+            print('<td>',stock_strings[0],'</td><td>',stock_strings[1],'</td><td>',stock_strings[2],'</td>')
             if count > 0:
                 if float(day14) > 0:
                     days_of_stock = float(count) *14.0/ float(day14)
-                    print '<td>','%.0f'%days_of_stock,' days</td>'
+                    print('<td>','%.0f'%days_of_stock,' days</td>')
                 else:
-                    print '''<td>No sales</td>'''
+                    print('''<td>No sales</td>''')
             else:
-                print '''<td>0 days</td>'''
+                print('''<td>0 days</td>''')
 
             speculated = count - day14/14*days_to_speculate   # days_to_speculate determined outside of loop
-            print '''<td id="%d_spec_%d" class="spec">''' % (item_id,i)
-            print '%d'%speculated,'''</td>'''
-            print '''<td id="%d_amt_%d" style="border-left: 1px solid #999; padding-left: 1em;">''' % (item_id, i)
-            print int(count),'''</td>'''
-            print '''<td><input class="count default" id="%d_count_%d" size="3" /></td>''' % (item_id,i)
-            print '''<td style='text-align: center;'> <a href="''',db.get_item_info_page_link(item_id),'''" target="_blank">''',str(item_id),'''</a> </td>'''
-            print '''<td>''',item.get_barcodes_str(),'''&nbsp;</td>'''
+            print('''<td id="%d_spec_%d" class="spec">''' % (item_id,i))
+            print('%d'%speculated,'''</td>''')
+            print('''<td id="%d_amt_%d" style="border-left: 1px solid #999; padding-left: 1em;">''' % (item_id, i))
+            print(int(count),'''</td>''')
+            print('''<td><input class="count default" id="%d_count_%d" size="3" /></td>''' % (item_id,i))
+            print('''<td style='text-align: center;'> <a href="''',db.get_item_info_page_link(item_id),'''" target="_blank">''',str(item_id),'''</a> </td>''')
+            print('''<td>''',item.get_barcodes_str(),'''&nbsp;</td>''')
             if not item.get_is_discontinued():
-                print '''<td><input type="checkbox" id="%d_isStocked" onClick="discontinueItem(this)" checked /> </td>''' % (item_id,)
+                print('''<td><input type="checkbox" id="%d_isStocked" onClick="discontinueItem(this)" checked /> </td>''' % (item_id,))
             else:
-                print '''<td><input type="checkbox" id="%d_isStocked"  onClick="discontinueItem(this)"/> </td>''' % (item_id,)                                             
-            print '''</div>'''
-            print '''</tr>\n'''
-    print '''</tbody></table>\n'''
-    print '''</body></html>'''
+                print('''<td><input type="checkbox" id="%d_isStocked"  onClick="discontinueItem(this)"/> </td>''' % (item_id,))
+            print('''</div>''')
+            print('''</tr>\n''')
+    print('''</tbody></table>\n''')
+    print('''</body></html>''')
 
 
 if __name__ == "__main__":

--- a/web/staff/op_tools/category_info.py
+++ b/web/staff/op_tools/category_info.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # category_info.py
 # Patrick McQuighan
 # 2/10/2011
 # This tool allows the user to see all items that are from a given category as well as general information
 # about the category such as:
 #   TBD
-# We allow for categoryid as a form input so that we can link from the item_info page. 
+# We allow for categoryid as a form input so that we can link from the item_info page.
 #  do this with ids since unlike the names they won't contain ', ,etc so I don't have to worry about escaping category names
 # in javascript and in python when generating the links.
 
@@ -13,19 +13,19 @@ import op_db_library as db
 import cgi
 
 def print_headers(catid=0,catname=''):
-    print '''Content-Type: text/html\n\n'''
+    print('''Content-Type: text/html\n\n''')
     if catid != 0:
         catname = db.get_category(catid).get_name()
     elif catname == '':
         catname = ''
-    print '''<html><head>
-    <title>Open Produce Category '%s' Info</title>''' % catname
-    print '''    <style type="text/css">
+    print('''<html><head>
+    <title>Open Produce Category '%s' Info</title>''' % catname)
+    print('''    <style type="text/css">
     table thead { background-color:#ddd; color:#333; font-weight: bold; cursor: default; }\n
     tr:nth-child(even) { background-color: #E0E0E0; };
     </style>
-    '''
-    print '''</head><body>'''
+    ''')
+    print('''</head><body>''')
 
 def main():
     form = cgi.FieldStorage()
@@ -36,35 +36,34 @@ def main():
         print_headers(catname=form.getvalue('categoryname'))
     else:
         print_headers()
-    
-    print '''<form name="category" action="category_info.py" method="get">'''
-    print '''Input a category name'''
-    print '''<input type="text" name="categoryname" size="4" /> <input type="submit" value="Display" />'''
-    print '''</form>'''
+
+    print('''<form name="category" action="category_info.py" method="get">''')
+    print('''Input a category name''')
+    print('''<input type="text" name="categoryname" size="4" /> <input type="submit" value="Display" />''')
+    print('''</form>''')
 
     category = None
 
-    if "categoryid" in form:   
+    if "categoryid" in form:
         categoryid = int(form.getvalue("categoryid"))
         category = db.get_category(categoryid)
     elif "categoryname" in form:
         try:
             category = db.get_category_byname(form.getvalue("categoryname"))
         except Exception:
-            print '''Error: category '%s' not found''' % form.getvalue("categoryname")
-    
+            print('''Error: category '%s' not found''' % form.getvalue("categoryname"))
+
     if category != None:
-        print '''<b>Info for category %s:</b><br />''' % category
-        
-        print '''<b>Items in this category </b><br/><table>
+        print('''<b>Info for category %s:</b><br />''' % category)
+
+        print('''<b>Items in this category </b><br/><table>
                    <thead>
                    <th>ItemID</th>
                    <th>Name</th>
-                   </thead>'''
+                   </thead>''')
         for item in db.get_items(show_categories=[category.get_name()], hide_categoryless=True):
-            print '''<tr><td><a href="%s">%d</a></td><td>%s</td></tr>''' % (db.get_item_info_page_link(item.get_id()),item.get_id(), item.get_name())
-        print '''</table>'''
+            print('''<tr><td><a href="%s">%d</a></td><td>%s</td></tr>''' % (db.get_item_info_page_link(item.get_id()),item.get_id(), item.get_name()))
+        print('''</table>''')
 
 if __name__ == "__main__":
     main()
-

--- a/web/staff/op_tools/db_config.py
+++ b/web/staff/op_tools/db_config.py
@@ -1,15 +1,14 @@
 register_tape_db_config = {
         "db_user" : "marzipan",
-        "db_pass" : "",
+        "db_pass" : "testpass",
         "db_host" : "localhost",
         "db_port" : 3306,
         "db_name" : "register_tape"
-} 
+}
 inventory_db_config = {
         "db_user" : "marzipan",
-        "db_pass" : "",
+        "db_pass" : "testpass",
         "db_host" : "localhost",
         "db_port" : 3306,
         "db_name" : "inventory"
-} 
-
+}

--- a/web/staff/op_tools/get_distributor_item.py
+++ b/web/staff/op_tools/get_distributor_item.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # get_distributor_item.py
 # Returns a comma separated string containing Distributor item id, wholesale price, case size and case units for a given item/distributor pair
 
@@ -6,7 +6,7 @@ import cgi
 import op_db_library as db
 
 form = cgi.FieldStorage()
-print 'Content-type: text/plain\n'
+print('Content-type: text/plain\n')
 
 itemid = int(form.getvalue('item'))
 item = db.get_item(itemid)
@@ -22,5 +22,4 @@ elif 'distid' in form:
 
 if dist != None:
     dist_item = db.get_distributor_item(item,dist)
-    print '%s,%d,%s,%.2f,%.2f,%s' % (dist.get_name(), dist.get_id(),dist_item.get_dist_item_id(), dist_item.get_wholesale_price(), dist_item.get_case_size(), dist_item.get_case_unit())
-
+    print('%s,%d,%s,%.2f,%.2f,%s' % (dist.get_name(), dist.get_id(),dist_item.get_dist_item_id(), dist_item.get_wholesale_price(), dist_item.get_case_size(), dist_item.get_case_unit()))

--- a/web/staff/op_tools/hours.py
+++ b/web/staff/op_tools/hours.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # hours.py
 # Patrick McQuighan
 # Replacement for hours.pl
@@ -7,7 +7,7 @@ import op_db_library as db
 import cgi, datetime
 
 def print_headers():
-    print '''Content-type: text/html\n\n
+    print('''Content-type: text/html\n\n
     <!doctype html>
     <html>
     <head>
@@ -25,14 +25,14 @@ def print_headers():
     </style>
     </head>
     <body>
-    '''
+    ''')
 
 def main():
     print_headers()
-    print '''Note: this values may be slightly inflated as they are the sum of sales including $ from taxes, however LINK transactions are not charged taxes, but this does not take that into consideration.  Use sales_tax.py if you need precise values eg for reporting sales taxes <br /> <br />'''
+    print('''Note: this values may be slightly inflated as they are the sum of sales including $ from taxes, however LINK transactions are not charged taxes, but this does not take that into consideration.  Use sales_tax.py if you need precise values eg for reporting sales taxes <br /> <br />''')
     form = cgi.FieldStorage()
     today = datetime.datetime.now()
-    
+
     if 'days' in form:
         days = int(form.getvalue('days'))
         if days == -1:
@@ -42,45 +42,45 @@ def main():
     else:
         start_date = today - datetime.timedelta(days=7)
     start_date += datetime.timedelta(hours=(-start_date.hour+db.DAY_START_HOUR))  # subtract current hour so reporting starts at midnight DAYS days ago.  add db.DAY_START_HOUR because this is the hour we want reporting to start.
-    print '''<form name="dates" action="hours.py" method="get">'''
-    print '''Show data for:'''
-    print '''<select name="days">'''
-    print '''<option value="7">Last 7 days</option>'''
-    print '''<option value="30">Last 30 days</option>'''
-    print '''<option value="-1">Since store open</option>'''
-    print '''</select>'''
+    print('''<form name="dates" action="hours.py" method="get">''')
+    print('''Show data for:''')
+    print('''<select name="days">''')
+    print('''<option value="7">Last 7 days</option>''')
+    print('''<option value="30">Last 30 days</option>''')
+    print('''<option value="-1">Since store open</option>''')
+    print('''</select>''')
 
-    print '''<input type="submit" value="Change date range" />'''
-    print '''<br /><br />'''
-    print "<table border='0' cellspacing='0'>\n"
-    print "<tr><th>Date</th><th>Dayname</th><th>Customers</th><th>$/ring</th><th>Gross</th>\n"
-    
-    hours = [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,0,1,2,3]    
+    print('''<input type="submit" value="Change date range" />''')
+    print('''<br /><br />''')
+    print("<table border='0' cellspacing='0'>\n")
+    print("<tr><th>Date</th><th>Dayname</th><th>Customers</th><th>$/ring</th><th>Gross</th>\n")
+
+    hours = [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,0,1,2,3]
     for i in hours:
-        print "<th style='padding-left: 1px; padding-right: 1px;' class=''>%d</th>" % (i,)
-    print "</tr>\n"
-    
+        print("<th style='padding-left: 1px; padding-right: 1px;' class=''>%d</th>" % (i,))
+    print("</tr>\n")
+
     day_infos = db.get_daily_sales(start_date,today)
     for i,key in enumerate(sorted(day_infos.keys())):
         day_info = day_infos[key]
-        print '<tr>'
-        print '<td>%s</td>' % (day_info.get_date_str(),)
-        print '<td>%s</td>' % (day_info.get_dayname(),)
+        print('<tr>')
+        print('<td>%s</td>' % (day_info.get_date_str(),))
+        print('<td>%s</td>' % (day_info.get_dayname(),))
 
-        print '''<td><div class='bar' style='width: %dpx;'>%d</td>''' % (day_info.get_customers_total()/2, day_info.get_customers_total())
-        print '''<td><div class='bar' style='width: %dpx;'>%.2f</td>''' % (day_info.get_avg_sales()*10, day_info.get_avg_sales())
-        print '''<td><div class='bar' style='width: %dpx;'>%.2f<div style='width: 1px; margin-top: -1em; margin-left: 110px; border-top: 1em solid black'></div></div></td>''' % (day_info.get_gross_sales()/10, day_info.get_gross_sales())
+        print('''<td><div class='bar' style='width: %dpx;'>%d</td>''' % (day_info.get_customers_total()/2, day_info.get_customers_total()))
+        print('''<td><div class='bar' style='width: %dpx;'>%.2f</td>''' % (day_info.get_avg_sales()*10, day_info.get_avg_sales()))
+        print('''<td><div class='bar' style='width: %dpx;'>%.2f<div style='width: 1px; margin-top: -1em; margin-left: 110px; border-top: 1em solid black'></div></div></td>''' % (day_info.get_gross_sales()/10, day_info.get_gross_sales()))
 
         for h in day_info.get_hourly_sales(hours):
-            print '''<td class='tiny' style='background-color: rgb(200,%d,200);'>%d<br/>%.1f<br/><b>$%d</b></td>\n''' % (255 - h.get_gross_sales()*1.3, h.get_customers(), h.get_avg_sales(), h.get_gross_sales())
+            print('''<td class='tiny' style='background-color: rgb(200,%d,200);'>%d<br/>%.1f<br/><b>$%d</b></td>\n''' % (255 - h.get_gross_sales()*1.3, h.get_customers(), h.get_avg_sales(), h.get_gross_sales()))
 
         if i == 0:  # print arrows on the first row
-            print "<td class='tiny' style='border: none;'>&larr;custs<br/>&larr;\$/ring<br/>&larr;gross</td>"
+            print("<td class='tiny' style='border: none;'>&larr;custs<br/>&larr;\$/ring<br/>&larr;gross</td>")
 
-        print '</tr>\n'
+        print('</tr>\n')
 
-    print '''</table>'''
-    print '''</body></html>'''
+    print('''</table>''')
+    print('''</body></html>''')
 
 if __name__ == "__main__":
     main()

--- a/web/staff/op_tools/inventory_history.py
+++ b/web/staff/op_tools/inventory_history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # inventory_history.py
 # Patrick McQuighan
 # Does some basic reporting about a particular item id
@@ -9,37 +9,37 @@ import cgitb
 cgitb.enable()
 
 def print_headers():
-    print '''Content-Type: text/html\n\n'''
-    print '''<html><head>
+    print('''Content-Type: text/html\n\n''')
+    print('''<html><head>
     <title>Open Produce Item History</title>
     <style type="text/css">
     td,tr { line-height: 14px; height: 14px; border-bottom: 1px solid #bbb; border-left: 1px solid #bbb;}\n
     tr:nth-child(even) { background-color: #E0E0E0; };
     </style>
     </head>
-    '''
+    ''')
 
 def main():
     print_headers()
-    print '''<body>'''
-    print '''<form name="item" action="inventory_history.py" method="get">'''
-    print '''Input an item SKU:'''
-    print '''<input type="text" name="itemid" size="4" /> <input type="submit" value="Display" />'''
-    print '''</form>'''
+    print('''<body>''')
+    print('''<form name="item" action="inventory_history.py" method="get">''')
+    print('''Input an item SKU:''')
+    print('''<input type="text" name="itemid" size="4" /> <input type="submit" value="Display" />''')
+    print('''</form>''')
     form = cgi.FieldStorage()
     if "itemid" in form:
         itemid = int(form.getvalue("itemid"))
         item = db.get_item(itemid)
-        print '''<br /> <b>30 day history for item %d (%s) </b><br />''' % (itemid, item)
+        print('''<br /> <b>30 day history for item %d (%s) </b><br />''' % (itemid, item))
         total_sales,total_deliveries,total_slush,history = db.get_item_history(itemid,30)
-        print '<b>Total sales: %d <br />' % (total_sales,)
-        print 'Total deliveries: %d <br />' % (total_deliveries,)
-        print 'Total slushfunded: %d <br /></b>' % (total_slush,)
-        print '''<table><thead><th>Date</th><th>+/-</th><th>Type</th></thead>'''
+        print('<b>Total sales: %d <br />' % (total_sales,))
+        print('Total deliveries: %d <br />' % (total_deliveries,))
+        print('Total slushfunded: %d <br /></b>' % (total_slush,))
+        print('''<table><thead><th>Date</th><th>+/-</th><th>Type</th></thead>''')
         for ttp in history:
-            print '''<tr><td>%s</td><td>%.2f</td><td>%s</td></tr>''' % ttp
-        print '''</table>'''
-    print '''</body></html>'''
+            print('''<tr><td>%s</td><td>%.2f</td><td>%s</td></tr>''' % ttp)
+        print('''</table>''')
+    print('''</body></html>''')
 
 if __name__ == "__main__":
     main()

--- a/web/staff/op_tools/inventory_stats.py
+++ b/web/staff/op_tools/inventory_stats.py
@@ -1,41 +1,41 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Patrick McQuighan
-# inventory_stats.py 
+# inventory_stats.py
 # This page provides stats on the inventory such as "top 10 slowest-selling items" etc
 
 import op_db_library as db
 import cgi
 
 def print_headers():
-    print '''Content-Type: text/html\n\n'''
-    print '''<html><head>
+    print('''Content-Type: text/html\n\n''')
+    print('''<html><head>
     <title>Open Produce Inventory Stats</title>
     </head>
-    <body>'''
+    <body>''')
 
 print_headers()
-print '''<h3>Top 10 items with most sales in the last 30 days</h3>'''
-print '''<table>
+print('''<h3>Top 10 items with most sales in the last 30 days</h3>''')
+print('''<table>
          <th>Rank</th>
          <th>OP Item ID</th>
          <th>Item name</th>
          <th>Sales</th>
-      '''
+      ''')
 for i,(itemid,sales) in enumerate(db.most_sold_items(10,30)):
     item = db.get_item(itemid)
-    print '''<tr><td>%d</td><td>%d</td><td>%s</td><td>%d</td></tr>''' % (i+1,itemid,item,sales)
-print '''</table>'''
+    print('''<tr><td>%d</td><td>%d</td><td>%s</td><td>%d</td></tr>''' % (i+1,itemid,item,sales))
+print('''</table>''')
 
-print '''<h3>Top 10 items with most sales in $ (not inc. tax) in the last 30 days </h3>'''
-print '''<table>
+print('''<h3>Top 10 items with most sales in $ (not inc. tax) in the last 30 days </h3>''')
+print('''<table>
          <th>Rank</th>
          <th>OP Item ID</th>
          <th>Item name</th>
          <th>Sales</th>
-      '''
+      ''')
 for i,(itemid,sales) in enumerate(db.most_dollar_items(10,30)):
     item = db.get_item(itemid)
-    print '''<tr><td>%d</td><td>%d</td><td>%s</td><td>$%.2f</td></tr>''' % (i+1,itemid,item,sales)
-print '''</table>'''
+    print('''<tr><td>%d</td><td>%d</td><td>%s</td><td>$%.2f</td></tr>''' % (i+1,itemid,item,sales))
+print('''</table>''')
 
-print '''</body></html>'''
+print('''</body></html>''')

--- a/web/staff/op_tools/item_display_form.py
+++ b/web/staff/op_tools/item_display_form.py
@@ -19,7 +19,7 @@ def init(form, discontinued=False, categories=False, distributors=False):
 
 def print_javascript():
     if categories_option:
-        print '''
+        print('''
          <script type="text/javascript">
          function allCategories(allbox){
             checked = allbox.checked;
@@ -28,9 +28,9 @@ def print_javascript():
               });
          }
          </script>
-         '''
+         ''')
     if distributors_option:
-        print '''
+        print('''
          <script type="text/javascript">
          function allDistributors(allbox){
             checked = allbox.checked;
@@ -39,75 +39,75 @@ def print_javascript():
               });
          }
          </script>
-         '''
+         ''')
 
 def print_categories():
-    print '''<br /> Select Categories to display:'''
+    print('''<br /> Select Categories to display:''')
     if "allCats" in input_form:
-        print '''<input name="allCats" type="checkbox" onClick="allCategories(this)" value="True" checked>All </input> <br />'''
+        print('''<input name="allCats" type="checkbox" onClick="allCategories(this)" value="True" checked>All </input> <br />''')
     else:
-        print '''<input name="allCats" type="checkbox" onClick="allCategories(this)" value="True">All </input> <br />'''
-    print'''
-<table cellspacing=0 cellpadding=2 style="border-top: 1px solid #999; border-left: 1px solid #999;">'''
+        print('''<input name="allCats" type="checkbox" onClick="allCategories(this)" value="True">All </input> <br />''')
+    print('''
+<table cellspacing=0 cellpadding=2 style="border-top: 1px solid #999; border-left: 1px solid #999;">''')
     hide_categories = []   # switching to displaying categories
 #    hide_categories = db.get_categories()
     for i,cat in enumerate(db.get_categories()):
         if i % 5 == 0:
             if i> 0:
-                print '''</tr>'''
-            print '''<tr>'''
+                print('''</tr>''')
+            print('''<tr>''')
 
         test_str = "cat_%s" % str(cat)
         if test_str in input_form:
-            print '''<td>%s</td><td style="border-right: 1px solid #999"><input class="categorybox" type="checkbox" name="cat_%s" value="True" checked/></td>''' % (cat,cat)
+            print('''<td>%s</td><td style="border-right: 1px solid #999"><input class="categorybox" type="checkbox" name="cat_%s" value="True" checked/></td>''' % (cat,cat))
             hide_categories.append(cat)
         else:
-            print '''<td>%s</td><td style="border-right: 1px solid #999"><input  class="categorybox" type="checkbox" name="cat_%s" value="True" /></td>''' % (cat, cat)
+            print('''<td>%s</td><td style="border-right: 1px solid #999"><input  class="categorybox" type="checkbox" name="cat_%s" value="True" /></td>''' % (cat, cat))
     if (i+1) % 5 == 0:
-        print '''</tr><tr>'''
+        print('''</tr><tr>''')
     if "cat_No Category" in input_form:
-        print '''<td>%s</td> <td style="border-right: 1px solid #999"><input class="categorybox" type="checkbox" name="cat_%s" value="True" checked/></td>''' % ("No Category", "No Category")
+        print('''<td>%s</td> <td style="border-right: 1px solid #999"><input class="categorybox" type="checkbox" name="cat_%s" value="True" checked/></td>''' % ("No Category", "No Category"))
         hide_categoryless = False
     else:
-        print '''<td>%s</td> <td style="border-right: 1px solid #999"><input class="categorybox"  type="checkbox" name="cat_%s" value="True"/></td>''' % ("No Category", "No Category")
+        print('''<td>%s</td> <td style="border-right: 1px solid #999"><input class="categorybox"  type="checkbox" name="cat_%s" value="True"/></td>''' % ("No Category", "No Category"))
         hide_categoryless = True
 
-    print '''</tr></table>'''
+    print('''</tr></table>''')
     return hide_categories,hide_categoryless
 
 def print_distributors():
-    print '''<br/><br/>Select distributors to display:'''
+    print('''<br/><br/>Select distributors to display:''')
     if "allDists" in input_form:
-        print '''<input name="allDists" type="checkbox" onClick="allDistributors(this)" value="True" checked>All </input><br/>'''
+        print('''<input name="allDists" type="checkbox" onClick="allDistributors(this)" value="True" checked>All </input><br/>''')
     else:
-        print '''<input name="allDists" type="checkbox" onClick="allDistributors(this)" value="True">All </input><br/>'''
+        print('''<input name="allDists" type="checkbox" onClick="allDistributors(this)" value="True">All </input><br/>''')
     dists = []
 
-    print '''<table cellspacing=0 cellpadding=2 style="border-top: 1px solid #999; border-left: 1px solid #999;">'''
-    
+    print('''<table cellspacing=0 cellpadding=2 style="border-top: 1px solid #999; border-left: 1px solid #999;">''')
+
     for i,dist in enumerate(db.get_distributors()):
         if i % 5 == 0:
             if i> 0:
-                print '''</tr>'''
-            print '''<tr>'''
+                print('''</tr>''')
+            print('''<tr>''')
         test_str = "dist_%s" % str(dist)
         if test_str in input_form:
             dists.append(dist)
-            print '''<td>%s</td> <td style="border-right: 1px solid #999"><input class="distributorbox" type="checkbox" name="dist_%s" value="True" checked/></td>''' % (dist,dist)
+            print('''<td>%s</td> <td style="border-right: 1px solid #999"><input class="distributorbox" type="checkbox" name="dist_%s" value="True" checked/></td>''' % (dist,dist))
         else:
-            print '''<td>%s</td><td  style="border-right: 1px solid #999"> <input class="distributorbox" type="checkbox" name="dist_%s" value="True"/> </td>''' % (dist,dist)
+            print('''<td>%s</td><td  style="border-right: 1px solid #999"> <input class="distributorbox" type="checkbox" name="dist_%s" value="True"/> </td>''' % (dist,dist))
 
     if (i+1) % 5 == 0:
-        print '''</tr><tr>'''
+        print('''</tr><tr>''')
     test_str = "dist_No Distributor"
     if test_str in input_form:
-        print '''<td>%s</td> <td style="border-right: 1px solid #999"><input class="distributorbox" type="checkbox" name="dist_%s" value="True" checked/></td>''' % ("No Distributor", "No Distributor")
+        print('''<td>%s</td> <td style="border-right: 1px solid #999"><input class="distributorbox" type="checkbox" name="dist_%s" value="True" checked/></td>''' % ("No Distributor", "No Distributor"))
         hide_distributorless = False
     else:
-        print '''<td>%s</td> <td style="border-right: 1px solid #999"><input class="distributorbox" type="checkbox" name="dist_%s" value="True"/></td>''' % ("No Distributor", "No Distributor")
+        print('''<td>%s</td> <td style="border-right: 1px solid #999"><input class="distributorbox" type="checkbox" name="dist_%s" value="True"/></td>''' % ("No Distributor", "No Distributor"))
         hide_distributorless = True
-    print '</tr></table><br />'
-    
+    print('</tr></table><br />')
+
     return dists, hide_distributorless
 
 def print_discontinued():
@@ -117,22 +117,22 @@ def print_discontinued():
         h_discontinued = False
 
     if h_discontinued:
-        print '''Hide discontinued items?<input type="checkbox" name="hide_discontinued" value="True" checked/><br />'''
+        print('''Hide discontinued items?<input type="checkbox" name="hide_discontinued" value="True" checked/><br />''')
     else:
-        print '''Hide discontinued items?<input type="checkbox" name="hide_discontinued" value="True"/><br />'''
+        print('''Hide discontinued items?<input type="checkbox" name="hide_discontinued" value="True"/><br />''')
 
     if "move_discontinued" in input_form:
         m_discontinued = input_form.getvalue("move_discontinued")
     else:
         m_discontinued = False
-    
+
     if m_discontinued:
-        print '''Move discontinued items to bottom of page?<input type="checkbox" name="move_discontinued" value="True" checked/><br/>'''
+        print('''Move discontinued items to bottom of page?<input type="checkbox" name="move_discontinued" value="True" checked/><br/>''')
     else:
-        print '''Move discontinued items to bottom of page?<input type="checkbox" name="move_discontinued" value="True" /><br/>'''
+        print('''Move discontinued items to bottom of page?<input type="checkbox" name="move_discontinued" value="True" /><br/>''')
 
     return h_discontinued,m_discontinued
-    
+
 def print_form():
     discont = False
     move = False
@@ -146,7 +146,7 @@ def print_form():
 
     if categories_option:
         show_categories,hide_categoryless = print_categories()
-    
+
     if distributors_option:
         show_distributors, hide_distributorless = print_distributors()
     return {'hide_discontinued' : discont, 'show_categories' : show_categories, 'show_distributors' : show_distributors, 'hide_distributorless' : hide_distributorless, 'hide_categoryless' : hide_categoryless, 'move_discontinued':move}

--- a/web/staff/op_tools/item_graphs.py
+++ b/web/staff/op_tools/item_graphs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # item_graphs.py
 # 2/2/2011
@@ -52,7 +52,7 @@ def price_graph(item,days):
     elif datetime.datetime.today().strftime('%m/%d/%y') not in x_labels:
         prices.append(prices[-1])
         x_labels.append(datetime.datetime.today().strftime('%m/%d/%y'))
-    make_graph(x_labels,'Day',[prices], 'Item price of a unit sold in the last %d days'%days,['Unit Price in $'],grid=False)    
+    make_graph(x_labels,'Day',[prices], 'Item price of a unit sold in the last %d days'%days,['Unit Price in $'],grid=False)
 
 def sales_graph(item,days):
     s = db.get_recent_item_sales(item,days,False)
@@ -64,7 +64,7 @@ def sales_graph(item,days):
     sale_counts = []   # sale in units for y-axis
 
     s_index = 0        # current sale to look at
-    s_len = len(s)    
+    s_len = len(s)
 
     for i in range(days):
         cur_date = start_date + datetime.timedelta(days=i)
@@ -72,7 +72,7 @@ def sales_graph(item,days):
             # Say cur_date = 1/4/11 1:00:00AM, then any sale occuring BEFORE then should be logged as on 1/3/11
             # Hence we subtract 1 from the date to get the label
             x_labels.append((cur_date-datetime.timedelta(days=1)).strftime('%m/%d/%y'))
-        else:  
+        else:
             # Don't want to clutterthe x-axis so we only print every third
             x_labels.append('')
 
@@ -104,7 +104,7 @@ if 'itemid' in form and 'graph' in form:
     itemid = int(form.getvalue('itemid'))
     graph = form.getvalue('graph')
     item = db.get_item(itemid)
-    print "Content-Type: image/png\n"
+    print("Content-Type: image/png\n")
     if graph == 'sales':
         sales_graph(item,30)
     if graph == 'prices':

--- a/web/staff/op_tools/item_info.py
+++ b/web/staff/op_tools/item_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # item_info.py
 # Patrick McQuighan
 # This file is meant to display all kinds of specific data about a given item
@@ -12,17 +12,17 @@ import cgitb
 cgitb.enable()
 
 def print_headers(key_handlers,select_handlers,itemid=0):
-    print '''Content-Type: text/html\n\n'''
-    print '''<html><head>
-    <title>Open Produce Item #%d Info</title>''' % itemid
-    print '''
+    print('''Content-Type: text/html\n\n''')
+    print('''<html><head>
+    <title>Open Produce Item #%d Info</title>''' % itemid)
+    print('''
     <link rel="stylesheet" type="text/css" href="../../common/tools.css" />
     <script type="text/javascript" src="../../common/jquery-1.3.2.min.js"></script>\n
-    <script type="text/javascript"> '''
-    print '''var itemid = %d;''' % itemid  # now itemid is a variable in the javascript space so we can just use that instead of passing things around
+    <script type="text/javascript"> ''')
+    print('''var itemid = %d;''' % itemid)  # now itemid is a variable in the javascript space so we can just use that instead of passing things around
 
     # Now print out a function that can fill out dropdowns with units for the case units field (needed for when we add a distributor)
-    print '''function setHandlers(){
+    print('''function setHandlers(){
         $('.count').keypress(function(e) {
                 if (e.which == 13) {
                         var id = parseInt(this.id);
@@ -43,19 +43,19 @@ def print_headers(key_handlers,select_handlers,itemid=0):
         });
 
     $('.op_price').keypress(handleOPPriceChange);
- '''
+ ''')
     for k_h in key_handlers:
         key_handlers[k_h].print_ready()
     for s_h in select_handlers:
         select_handlers[s_h].print_ready()
-    print '''}'''
+    print('''}''')
 
     for k_h in key_handlers:
         key_handlers[k_h].print_function()
     for s_h in select_handlers:
         select_handlers[s_h].print_function()
 
-    print '''
+    print('''
     function trim(str) {
        return str.replace(/^[\s]+/g,'').replace(/[\s]+$/g,'');
     }
@@ -82,12 +82,12 @@ def print_headers(key_handlers,select_handlers,itemid=0):
           } else if(margin <= 30) {
               $('#'+ditem_id+'_margin').attr('class','mid');
           } else{
-              $('#'+ditem_id+'_margin').attr('class','good');                 
+              $('#'+ditem_id+'_margin').attr('class','good');
           }
         }
     },'text');
-   } '''
-    print '''
+   } ''')
+    print('''
   function removeBarcode(bc_item_id) {
     $.post('update_barcode_item.py', {action : 'remove', bc_item_id : bc_item_id},
       function(data){
@@ -100,15 +100,15 @@ def print_headers(key_handlers,select_handlers,itemid=0):
 
    function addBarcode() {
      var selected = $('#new_barcode').val();
-     
+
      $.post('update_barcode_item.py', {action : 'add', item_id : itemid, barcode: selected},
        function(data){
          if(data.indexOf('Error:') != -1) { alert(data); }
          else {
             var newid = parseInt(data);
             var newrow = '<tr id="'+newid+'_barcode_tr">';
-            newrow += '<td><input type="text" class="%s" id="'+newid+'_bc" value="'+selected+'" size="16"/></td>'; ''' % (key_handlers['barcode'].element)
-    print '''
+            newrow += '<td><input type="text" class="%s" id="'+newid+'_bc" value="'+selected+'" size="16"/></td>'; ''' % (key_handlers['barcode'].element))
+    print('''
             newrow += '<td><button input="button" onClick="removeBarcode('+newid+')">remove</button></td></tr>';
             $('#barcodes').append(newrow);
             $('#new_barcode').val('');
@@ -155,7 +155,7 @@ def print_headers(key_handlers,select_handlers,itemid=0):
            else{
              $('#'+dist_item_id+'_dist_tr').remove();
            }
-        }, 'text');      
+        }, 'text');
    }
 
    function updateItemString() {
@@ -205,7 +205,7 @@ def print_headers(key_handlers,select_handlers,itemid=0):
                     if(data.indexOf('Error:') != -1) { alert(data);}
                     else{ $box.removeClass('default').removeClass('submitting').addClass('complete'); updateAllMargins();}
                   },'text');
-                  
+
               }
             }
             else{ $box.removeClass('default').removeClass('submitting').addClass('complete'); updateAllMargins();}
@@ -235,26 +235,26 @@ def print_headers(key_handlers,select_handlers,itemid=0):
 
    function addDistributor(){
       var selected = $('#new_distributor').val();
-      $.post('update_distributor_item.py', { action: 'add', distid : selected, item : itemid, item_info : true }, 
+      $.post('update_distributor_item.py', { action: 'add', distid : selected, item : itemid, item_info : true },
         function(data){
            if(data.indexOf('Error:') != -1) { alert(data); }
            else {
              // data contains the dist_item_id for the newly added distributor_item
              var newid = parseInt(data);
              newrow = '<tr id="'+newid+'_dist_tr">';
-             newrow += '<td>' + $('#new_distributor option:selected').text() + '</td>'; '''
-    print ' '*13 + '''newrow += '<td> <input type="text" class="%s" id="'+newid+'_ditemid" value="0" size="16" /></td>'; ''' % key_handlers['ditemid'].element
-    print ' '*13 + '''newrow += '<td><input type="text" class="%s" id="'+newid+'_casesize" value="0.00" size="4" /></td>'; ''' % key_handlers['casesize'].element
-    print ' '*13 +  '''newrow += '<td><select class="%s" id="'+newid+'_caseunits">'; ''' % select_handlers['caseunit'].element
+             newrow += '<td>' + $('#new_distributor option:selected').text() + '</td>'; ''')
+    print(' '*13 + '''newrow += '<td> <input type="text" class="%s" id="'+newid+'_ditemid" value="0" size="16" /></td>'; ''' % key_handlers['ditemid'].element)
+    print(' '*13 + '''newrow += '<td><input type="text" class="%s" id="'+newid+'_casesize" value="0.00" size="4" /></td>'; ''' % key_handlers['casesize'].element)
+    print(' '*13 +  '''newrow += '<td><select class="%s" id="'+newid+'_caseunits">'; ''' % select_handlers['caseunit'].element)
     for u in db.get_units():
-        print ' '*13 + '''newrow += '<option value="%d"> %s </option>' ''' % (u.get_id(), u)
-    print ' '*13 + '''newrow += '</select></td>';  '''
-    print ' '*13 + '''newrow += '<td>$<input type="text" class="%s" id="'+newid+'_caseprice" value="0.00" size="5" /> </td>'; ''' % key_handlers['caseprice'].element
-    print '''
+        print(' '*13 + '''newrow += '<option value="%d"> %s </option>' ''' % (u.get_id(), u))
+    print(' '*13 + '''newrow += '</select></td>';  ''')
+    print(' '*13 + '''newrow += '<td>$<input type="text" class="%s" id="'+newid+'_caseprice" value="0.00" size="5" /> </td>'; ''' % key_handlers['caseprice'].element)
+    print('''
 	      newrow += '<td width="80" id="'+newid+'_each"></td>';
               newrow += '<td width="80" id="'+newid+'_margin"></td>';
-'''
-    print ' '*13 + '''newrow += '<td><button type="button" onClick="removeDistributor('+newid+')">remove</button></td>';
+''')
+    print(' '*13 + '''newrow += '<td><button type="button" onClick="removeDistributor('+newid+')">remove</button></td>';
 
              newrow += '</tr>';
              $('#distributors').append(newrow);
@@ -264,23 +264,23 @@ def print_headers(key_handlers,select_handlers,itemid=0):
         }, 'text');
    }
 
-   $(document).ready(function() {      
+   $(document).ready(function() {
        setHandlers();
      }); // end document.ready
     </script>
-    '''
-    print '''</head>
-    <body>'''
+    ''')
+    print('''</head>
+    <body>''')
 
 def print_unit_options(selected):
     for unit in db.get_units():
         if unit.get_id() == selected:
-            print '<option value="%d" selected> %s </option>' % (unit.get_id(), unit.get_name())
+            print('<option value="%d" selected> %s </option>' % (unit.get_id(), unit.get_name()))
         else:
-            print '<option value="%d"> %s </option>' % (unit.get_id(), unit.get_name())
+            print('<option value="%d"> %s </option>' % (unit.get_id(), unit.get_name()))
 
 def print_distributor_items(item,key_handlers,select_handlers):
-    print '''<table id="distributors">
+    print('''<table id="distributors">
                  <thead>
                  <th>Distributor</th>
                  <th>Dist Item ID</th>
@@ -290,16 +290,16 @@ def print_distributor_items(item,key_handlers,select_handlers):
                  <th>Each Price</th>
                  <th>Margin</th>
                  <th>Remove</th>
-                 </thead>'''
+                 </thead>''')
     for ditem in item.get_distributor_items():
-        print '''<tr id="%d_dist_tr">''' % (ditem.get_id(),)
+        print('''<tr id="%d_dist_tr">''' % (ditem.get_id(),))
         dist = db.get_distributor(ditem.get_dist_id())
-        print '''<td> %s</td><td> <input type="text" class="%s" id="%d_ditemid" value="%s" size="16" /></td>''' % (dist,key_handlers['ditemid'].element,ditem.get_id(),ditem.get_dist_item_id())
-        print '''<td><input type="text" class="%s" id="%d_casesize" value="%.2f" size="4" /> </td>''' % (key_handlers['casesize'].element,ditem.get_id(), ditem.get_case_size())
-        print '''<td><select class="%s" id="%d_caseunits">''' % (select_handlers['caseunit'].element,ditem.get_id())
+        print('''<td> %s</td><td> <input type="text" class="%s" id="%d_ditemid" value="%s" size="16" /></td>''' % (dist,key_handlers['ditemid'].element,ditem.get_id(),ditem.get_dist_item_id()))
+        print('''<td><input type="text" class="%s" id="%d_casesize" value="%.2f" size="4" /> </td>''' % (key_handlers['casesize'].element,ditem.get_id(), ditem.get_case_size()))
+        print('''<td><select class="%s" id="%d_caseunits">''' % (select_handlers['caseunit'].element,ditem.get_id()))
         print_unit_options(ditem.get_case_unit_id())
-        print '''</select></td>'''
-        print '''<td>$<input type="text" class="%s" id="%d_caseprice" value="%.2f" size="5" /></td>''' % (key_handlers['caseprice'].element,ditem.get_id(), ditem.get_wholesale_price())
+        print('''</select></td>''')
+        print('''<td>$<input type="text" class="%s" id="%d_caseprice" value="%.2f" size="5" /></td>''' % (key_handlers['caseprice'].element,ditem.get_id(), ditem.get_wholesale_price()))
 
         each_cost = ditem.get_each_cost()
         op_price = item.get_price()
@@ -310,78 +310,78 @@ def print_distributor_items(item,key_handlers,select_handlers):
         else:
             margin = 100
 
-	print '''<td width="80" id="%d_each">$%.2f </td>''' % (ditem.get_id(),each_cost)
+        print('''<td width="80" id="%d_each">$%.2f </td>''' % (ditem.get_id(),each_cost))
         if margin <= 20:
-            print '''<td width="80" class="bad" id="%d_margin"> %.0f%% &nbsp;</td>''' % (ditem.get_id(), margin)
+            print('''<td width="80" class="bad" id="%d_margin"> %.0f%% &nbsp;</td>''' % (ditem.get_id(), margin))
         elif margin <= 30:
-            print '''<td width="80" class="mid" id="%d_margin"> %.0f%% &nbsp; </td>''' % (ditem.get_id(), margin)
+            print('''<td width="80" class="mid" id="%d_margin"> %.0f%% &nbsp; </td>''' % (ditem.get_id(), margin))
         else:
-            print '''<td width="80" class="good" id="%d_margin"> %.0f%% &nbsp; </td>''' % (ditem.get_id(), margin)
+            print('''<td width="80" class="good" id="%d_margin"> %.0f%% &nbsp; </td>''' % (ditem.get_id(), margin))
 
-        print '''<td><button type="button" onClick="removeDistributor(%d)">remove</button></td>''' % (ditem.get_id(),)
+        print('''<td><button type="button" onClick="removeDistributor(%d)">remove</button></td>''' % (ditem.get_id(),))
 
-        print '</tr>'
-    print '</table>'
-    print '''<select id="new_distributor">'''
+        print('</tr>')
+    print('</table>')
+    print('''<select id="new_distributor">''')
     for dist in db.get_distributors():
-        print '''<option value="%d"> %s </option>''' % (dist.get_id(), dist)
-    print '''</select>'''
-    print '''<button type="button" onClick="addDistributor()"> Add Distributor</button>'''
+        print('''<option value="%d"> %s </option>''' % (dist.get_id(), dist))
+    print('''</select>''')
+    print('''<button type="button" onClick="addDistributor()"> Add Distributor</button>''')
 
 def print_tax_category_options(selected):
     for taxcat in db.get_tax_categories():
         if taxcat == selected:
-            print '<option value="%d" selected> %s </option>' % (taxcat.get_id(), taxcat)
+            print('<option value="%d" selected> %s </option>' % (taxcat.get_id(), taxcat))
         else:
-            print '<option value="%d"> %s </option>' % (taxcat.get_id(), taxcat)
-    
+            print('<option value="%d"> %s </option>' % (taxcat.get_id(), taxcat))
+
 def print_tax_categories(item,select_handlers):
-    print '<select class="%s">' % (select_handlers['taxcat'].element)
+    print('<select class="%s">' % (select_handlers['taxcat'].element))
     print_tax_category_options(item.get_tax_category())
-    print '</select>'
+    print('</select>')
 
 def print_categories(item):
-    print '<table id="categories">'
-    print '''<thead>
+    print('<table id="categories">')
+    print('''<thead>
           <th>Category</th>
           <th>Remove</th>
-          </thead>'''
+          </thead>''')
     for category_item in item.get_category_items():
         category = db.get_category(category_item.get_cat_id())
-        print '''<tr id="%d_category_tr"><td><a href="%s">%s</a></td><td><button type="button" onClick="removeCategory(%d)"> remove </button> </td>''' % (category_item.get_id(),db.get_category_info_page_link(category.get_id()),category.get_name(),category_item.get_id())
-    print '''</table>'''
-    print '<select id="new_category">'
+        print('''<tr id="%d_category_tr"><td><a href="%s">%s</a></td><td><button type="button" onClick="removeCategory(%d)"> remove </button> </td>''' % (category_item.get_id(),db.get_category_info_page_link(category.get_id()),category.get_name(),category_item.get_id()))
+    print('''</table>''')
+    print('<select id="new_category">')
     for cat in db.get_categories():
-        print '''<option value="%d"> %s </option>''' % (cat.get_id(), cat)
-    print '</select>'
-    print '''<button type="button" onClick="addCategory()"> Add Category </button>'''
-    print '<br />'*2
+        print('''<option value="%d"> %s </option>''' % (cat.get_id(), cat))
+    print('</select>')
+    print('''<button type="button" onClick="addCategory()"> Add Category </button>''')
+    print('<br />'*2)
 
 def print_item_history(item):
-    print '''<br /> <b>30 day history for item %d (%s) </b><br />''' % (item.get_id(), item)
+    print('''<br /> <b>30 day history for item %d (%s) </b><br />''' % (item.get_id(), item))
     total_sales,total_deliveries,total_slush,history = db.get_item_history(item.get_id(),30)
-    print '<b>Total sales: %d <br />' % (total_sales,)
-    print 'Total deliveries: %d <br />' % (total_deliveries,)
-    print 'Total slushfunded: %d <br /></b>' % (total_slush,)
-    print '''<table><thead><th>Date</th><th>+/-</th><th>Type</th></thead>'''
+    print('<b>Total sales: %d <br />' % (total_sales,))
+    print('Total deliveries: %d <br />' % (total_deliveries,))
+    print('Total slushfunded: %d <br /></b>' % (total_slush,))
+    print('''<table><thead><th>Date</th><th>+/-</th><th>Type</th></thead>''')
     for ttp in history:
-        print '''<tr><td>%s</td><td>%.2f</td><td>%s</td></tr>''' % ttp
-    print '''</table>'''
+        print('''<tr><td>%s</td><td>%.2f</td><td>%s</td></tr>''' % ttp)
+    print('''</table>''')
 
 def print_barcodes(item,key_handlers):
-    print '''<table id="barcodes">
+    print('''<table id="barcodes">
              <thead>
              <th>Barcode</th>
              <th>Remove</th>
-             </thead>'''
+             </thead>''')
 
     for bc in item.get_barcodes():
-            print '''<tr id="%d_barcode_tr"><td><input type="text" class="%s" id="%d_bc" value="%s" size="16"/></td>''' % (bc.get_id(),key_handlers['barcode'].element,bc.get_id(), bc.get_barcode())
-            print '''<td><button input="button" onClick="removeBarcode(%d)">remove</button></td></tr>''' % (bc.get_id())
-    print '''</table>'''
-    print '''<input type="text" id="new_barcode" value="" size="16"/>'''
-    print '''<button type="button" onClick="addBarcode()"> Add Barcode </button>'''
-    print '''<br /><br />'''
+            print('''<tr id="%d_barcode_tr"><td><input type="text" class="%s" id="%d_bc" value="%s" size="16"/></td>''' % (bc.get_id(),key_handlers['barcode'].element,bc.get_id(), bc.get_barcode()))
+            print('''<td><button input="button" onClick="removeBarcode(%d)">remove</button></td></tr>''' % (bc.get_id()))
+    print('''</table>''')
+    print('''<input type="text" id="new_barcode" value="" size="16"/>''')
+    print('''<button type="button" onClick="addBarcode()"> Add Barcode </button>''')
+    print('''<br /><br />''')
 
 def main():
     form = cgi.FieldStorage()
@@ -393,7 +393,7 @@ def main():
     # we index into the key_handlers list to add the appropriate key handler to that object
     key_handlers = {'ditemid' : KeyHandler('handleDistItemIdChange','changes the distributor_item.dist_item_id field',ENTER_KEY,
                                            'update_distributor_item.py',{'action':'update_byid','dist_item_id':TEXTBOX_ID,'distitemid':TEXTBOX_VALUE},'','ditemid'),
-                    
+
                     'casesize' : KeyHandler('handleCaseSizeChange','changes the case size of a distributor_item',ENTER_KEY,
                                             'update_distributor_item.py',{'action':'update_byid','dist_item_id':TEXTBOX_ID,'casesize':TEXTBOX_VALUE},
                                             'updateMargin(id)','casesize'),
@@ -426,59 +426,59 @@ def main():
 
     print_headers(key_handlers,select_handlers,itemid)
 
-    print '''<form name="item" action="item_info.py" method="get">'''
-    print '''Input an item SKU'''
-    print '''<input type="text" name="itemid" size="4" /> <input type="submit" value="Display" />'''
-    print '''</form>'''
+    print('''<form name="item" action="item_info.py" method="get">''')
+    print('''Input an item SKU''')
+    print('''<input type="text" name="itemid" size="4" /> <input type="submit" value="Display" />''')
+    print('''</form>''')
 
     if "itemid" in form:
         itemid = int(form.getvalue("itemid"))
         if not db.is_item(itemid):
-            print '''Item %d not found''' % itemid
+            print('''Item %d not found''' % itemid)
             sys.exit(0)
         item = db.get_item(itemid)
-        print '''<b><div id="item_string">OP SKU  %d: %s</div></b><br />''' % (itemid, item)
-        print '''Name: <input type="text" size="40" class="%s" value="%s" /> <br />''' % (key_handlers['name'].element, item.get_name())
-        print '''Item size: <input type="text" size="5" class="%s" value="%.2f" /> &nbsp;''' % (key_handlers['itemsize'].element, item.get_unit_size())
-        print ''' <select class="%s">''' % (select_handlers['itemsize'].element)
+        print('''<b><div id="item_string">OP SKU  %d: %s</div></b><br />''' % (itemid, item))
+        print('''Name: <input type="text" size="40" class="%s" value="%s" /> <br />''' % (key_handlers['name'].element, item.get_name()))
+        print('''Item size: <input type="text" size="5" class="%s" value="%.2f" /> &nbsp;''' % (key_handlers['itemsize'].element, item.get_unit_size()))
+        print(''' <select class="%s">''' % (select_handlers['itemsize'].element))
         print_unit_options(item.get_size_unit_id())
-        print '''</select> <br />'''
-        print '''Tax category:''' 
+        print('''</select> <br />''')
+        print('''Tax category:''')
         print_tax_categories(item,select_handlers)
-        print '''<br />'''
-        print '''OP Price: $<input type="text" size="5" class="op_price" value="%.2f" id="%d_op_price" />''' % (item.get_price(),item.get_id())
-        print '''<br />'''
-#        print '''OP in store count: %d''' % (item.get_count())
-        print '''OP in store count: <input type="text" size="5" class="count" value="%d" id="%d_count" />''' % (item.get_count(),item.get_id())
-        print '''<br />'''
-        print '''Stocked:'''
+        print('''<br />''')
+        print('''OP Price: $<input type="text" size="5" class="op_price" value="%.2f" id="%d_op_price" />''' % (item.get_price(),item.get_id()))
+        print('''<br />''')
+#        print('''OP in store count: %d''' % (item.get_count()))
+        print('''OP in store count: <input type="text" size="5" class="count" value="%d" id="%d_count" />''' % (item.get_count(),item.get_id()))
+        print('''<br />''')
+        print('''Stocked:''')
         if not item.get_is_discontinued():
-            print '''<input type="checkbox" id="%d_isStocked" onClick="discontinueItem(this)" checked />''' % (itemid,)
+            print('''<input type="checkbox" id="%d_isStocked" onClick="discontinueItem(this)" checked />''' % (itemid,))
         else:
-            print '''<input type="checkbox" id="%d_isStocked"  onClick="discontinueItem(this)"/>''' % (itemid,)
- 
-        print '''<br />'''*2
+            print('''<input type="checkbox" id="%d_isStocked"  onClick="discontinueItem(this)"/>''' % (itemid,))
+
+        print('''<br />'''*2)
         print_barcodes(item,key_handlers)
         print_categories(item)
         print_distributor_items(item,key_handlers,select_handlers)
-        print '''<br /> <br />'''
-        #print '''Merge this item into item with OP SKU:'''
-        #print '''<input type="text" id="merge" size="4" />'''
-        #print '''<button type="button" id="merge_btn" onClick="mergeItem()"> Merge </button><br /><br />'''
-        print '''Notes: <br /><textarea id="notes" cols="40" rows="4">%s</textarea><br />''' % (item.get_notes())
-        print '''<button type="button" onClick="updateNotes()">Update Notes</button><br />'''
-        print '''<br /> <br /><button type="button" id="history_button" onClick="toggleHistory()"> Show History </button>'''
-        print '''<br />'''
-        print '''<div id="history" style="display: none">'''
+        print('''<br /> <br />''')
+        #print('''Merge this item into item with OP SKU:''')
+        #print('''<input type="text" id="merge" size="4" />''')
+        #print('''<button type="button" id="merge_btn" onClick="mergeItem()"> Merge </button><br /><br />''')
+        print('''Notes: <br /><textarea id="notes" cols="40" rows="4">%s</textarea><br />''' % (item.get_notes()))
+        print('''<button type="button" onClick="updateNotes()">Update Notes</button><br />''')
+        print('''<br /> <br /><button type="button" id="history_button" onClick="toggleHistory()"> Show History </button>''')
+        print('''<br />''')
+        print('''<div id="history" style="display: none">''')
         print_item_history(item)
-        print '''</div>'''
-        print '''<br /><button type="button" id="graph_button" onClick="toggleGraph()"> Show Graph </button>'''
-        print '''<div id="graph" style="display: none">'''
-        print '''<img src="item_graphs.py?itemid=%d&graph=sales" alt="%d_sales">''' % (itemid,itemid)
-        print '''<img src="item_graphs.py?itemid=%d&graph=prices" alt=%d_prices">''' % (itemid, itemid)
-        print '''</div>'''
+        print('''</div>''')
+        print('''<br /><button type="button" id="graph_button" onClick="toggleGraph()"> Show Graph </button>''')
+        print('''<div id="graph" style="display: none">''')
+        print('''<img src="item_graphs.py?itemid=%d&graph=sales" alt="%d_sales">''' % (itemid,itemid))
+        print('''<img src="item_graphs.py?itemid=%d&graph=prices" alt=%d_prices">''' % (itemid, itemid))
+        print('''</div>''')
 
-    print '''</body></html>'''
+    print('''</body></html>''')
 
 if __name__ == "__main__":
     main()

--- a/web/staff/op_tools/item_search.py
+++ b/web/staff/op_tools/item_search.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # item_search.py
 # Patrick McQuighan
 # Searches database for any matching item names and displays their name and gives a link to the item info page
@@ -7,13 +7,13 @@ import op_db_library as db
 import cgi
 
 def print_headers():
-    print 'Content-type: text/html\n'
-    print '''<html>
+    print('Content-type: text/html\n')
+    print('''<html>
 <head><title>Item Search</title>
     <link rel="stylesheet" type="text/css" href="../../tools.css" />
 </head>
 <body>
-'''
+''')
 
 def main():
     print_headers()
@@ -23,26 +23,26 @@ def main():
     else:
         search = None
 
-    print '''<form name="item_search" action="item_search.py" method="get">'''
-    print '''Enter all or part of an item name to search for:'''
+    print('''<form name="item_search" action="item_search.py" method="get">''')
+    print('''Enter all or part of an item name to search for:''')
     if search == None:
-        print '''<input type="text" id="search" name="search" />'''
+        print('''<input type="text" id="search" name="search" />''')
     else:
-        print '''<input type="text" id="search" name="search" value="%s" />''' % (search)
-    print '''<input type="submit" value="Search" />'''
-    print '''</form>'''
-        
+        print('''<input type="text" id="search" name="search" value="%s" />''' % (search))
+    print('''<input type="submit" value="Search" />''')
+    print('''</form>''')
+
     if search != None:
         results = db.search_for_item(search)
-        print '<table><thead><tr><th>SKU</th><th>Name</th></tr></thead>'
-        print '<tbody>'
+        print('<table><thead><tr><th>SKU</th><th>Name</th></tr></thead>')
+        print('<tbody>')
         for item in results:
             itemid = item.get_id()
-            print '<tr><td>',itemid,'</td>'
-            print '<td><a href="%s" target="_blank"> %s </a></td>' % (db.get_item_info_page_link(itemid), item)
-            print '</tr>'
-        print '</tbody></table>'
-    print '</body></html>'
+            print('<tr><td>',itemid,'</td>')
+            print('<td><a href="%s" target="_blank"> %s </a></td>' % (db.get_item_info_page_link(itemid), item))
+            print('</tr>')
+        print('</tbody></table>')
+    print('</body></html>')
 
 if __name__ == "__main__":
     main()

--- a/web/staff/op_tools/make_dinnerrush_sales_csv.py
+++ b/web/staff/op_tools/make_dinnerrush_sales_csv.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # make_dinnerrush_sales_csv.py
 # Steven Lucy
 # This file generates a .csv file which is used to make a dygraphs graph.
-# The data outputted are: 
+# The data outputted are:
 #   Date, Sales between 5pm-9pm, # customers between 5pm-9pm
 
 import op_db_library as db
@@ -16,7 +16,7 @@ outputfile.write('"Date",Gross $,Customers\n')
 for key in sorted(daily_sales.keys()):
     day_info = daily_sales[key]
     date = day_info.get_date().strftime(format)
-   
+
     customers = 0
     gross = 0
     for h in day_info.get_hourly_sales(hours):
@@ -24,4 +24,3 @@ for key in sorted(daily_sales.keys()):
         gross += h.get_gross_sales()
 
     outputfile.write("%s,%.2f,%d\n" % (date,gross,customers))
-

--- a/web/staff/op_tools/make_javascript.py
+++ b/web/staff/op_tools/make_javascript.py
@@ -48,7 +48,7 @@ function %s(e) {''' % self.name
         to_print += '''
     $.post('%s', {''' % self.post_to
         varcount = len(self.post_vars.keys())
-        for i,(varname,value) in enumerate(self.post_vars.iteritems()):
+        for i,(varname,value) in enumerate(self.post_vars.items()):
             if value == TEXTBOX_VALUE:
                 to_print += '''%s:%s''' % (varname,'value')
             elif value == TEXTBOX_ID:
@@ -96,7 +96,7 @@ function %s(){''' % (self.name)
         to_print += '''
   $.post('%s', { ''' % self.post_to
         varcount = len(self.post_vars.keys())
-        for i,(varname,value) in enumerate(self.post_vars.iteritems()):
+        for i,(varname,value) in enumerate(self.post_vars.items()):
             if value == SELECT_VALUE:
                 to_print += '''%s:%s''' % (varname,'selected')
             elif value == SELECT_ID:

--- a/web/staff/op_tools/make_javascript.py
+++ b/web/staff/op_tools/make_javascript.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # 1/31/2011
 # Patrick McQuighan
 # This is sort of an experimental class thing where I try to prevent myself from typing out the
-# same sort of javascript a million times.  
+# same sort of javascript a million times.
 #The first class here is a simple KeyHandler class
 # which is supposed to print out a javascript function (which I use all over the place) which
 # when the enter key is pressed will take the value from the textbox, and the id # from the
-# textbox's .id field and pass that to one of the update_ scripts and then do something on 
+# textbox's .id field and pass that to one of the update_ scripts and then do something on
 # a succesfull update
 
 # Instead of passing a whole bunch of params like '' have macros eg NO_ARGS, EMPTY_FUNC
@@ -19,7 +19,7 @@ SELECT_VALUE = 0
 SELECT_ID = 1
 
 class KeyHandler():
-    def __init__(self,name, doc, key_pressed, post_to, 
+    def __init__(self,name, doc, key_pressed, post_to,
                  post_vars,on_success,element):
         '''post_vars is a dictionary of var_name : string which gets passed to post_to as post_to?var_name=string
         element is the corresponding CLASS name to which this handler is added'''
@@ -29,7 +29,7 @@ class KeyHandler():
         self.post_to = post_to
         self.post_vars = post_vars
         self.on_success = on_success
-        self.element = element 
+        self.element = element
 
     def print_function(self):
         to_print = ''
@@ -68,10 +68,10 @@ function %s(e) {''' % self.name
   }
   setTimeout(function(box) { $(box).removeClass('submitting').removeClass('complete').addClass('default');}, 4000, box);
 }'''
-        print to_print
+        print(to_print)
 
     def print_ready(self):
-        print '''  $('.%s').keypress(%s); ''' % (self.element, self.name)
+        print('''  $('.%s').keypress(%s); ''' % (self.element, self.name))
 
 
 class SelectHandler():
@@ -82,8 +82,8 @@ class SelectHandler():
         self.post_to = post_to
         self.post_vars = post_vars
         self.on_success = on_success
-        self.element = element 
-    
+        self.element = element
+
     def print_function(self):
         to_print = ''
         to_print += '''
@@ -114,7 +114,7 @@ function %s(){''' % (self.name)
         to_print += '''
     }, 'text');
 }'''
-        print to_print
+        print(to_print)
 
     def print_ready(self):
-        print '''  $('.%s').change(%s); ''' % (self.element,self.name)
+        print('''  $('.%s').change(%s); ''' % (self.element,self.name))

--- a/web/staff/op_tools/make_latenight_sales_csv.py
+++ b/web/staff/op_tools/make_latenight_sales_csv.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # make_latenight_sales_csv.py
 # Patrick McQuighan
 # This file generates a .csv file which is used to make a dygraphs graph.
-# The data outputted are: 
+# The data outputted are:
 #   Date, Sales between 11pm-4am, # customers between 11pm-4am
 
 import op_db_library as db
@@ -16,7 +16,7 @@ outputfile.write('"Date",Gross $,Customers\n')
 for key in sorted(daily_sales.keys()):
     day_info = daily_sales[key]
     date = day_info.get_date().strftime(format)
-   
+
     customers = 0
     gross = 0
     for h in day_info.get_hourly_sales(hours):
@@ -24,4 +24,3 @@ for key in sorted(daily_sales.keys()):
         gross += h.get_gross_sales()
 
     outputfile.write("%s,%.2f,%d\n" % (date,gross,customers))
-

--- a/web/staff/op_tools/manage_categories.py
+++ b/web/staff/op_tools/manage_categories.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # manage_categories.py
 # This page lets the user add new categories as well as modify information about old ones
 
 import op_db_library as db
 
-print '''Content-Type: text/html\n\n'''
-print '''<html><head>
+print('''Content-Type: text/html\n\n''')
+print('''<html><head>
     <title>Open Produce Category Manager</title>
     <style type="text/css">
       * { font-family: sans-serif; font-size: 12px;}
@@ -30,7 +30,7 @@ print '''<html><head>
              $('td[onClick*=editCategory]:contains('+catname+')', window.parent.main.document).html($('td[onClick*=editCategory]:contains('+catname+')', window.parent.main.document).html().replace(catname,''));
            }
          }, 'text');
-    } 
+    }
     function addCategory() {
        var catname = $('#newCatName').val();
        if (catname != ''){
@@ -58,24 +58,24 @@ print '''<html><head>
 
    </script>
     </head>
-    '''
+    ''')
 
-print '''<body>
+print('''<body>
 <table border=0  cellspacing=2 cellpadding=0>
 <thead><tr>
 <th>Category</th>
 <th>Remove</th>
 </thead>
 <tbody id="categories">
-'''
+''')
 
 for cat in db.get_categories():
-    print '''<tr class="%d_cat_tr" id="%d_cat_tr"><td>%s</td>''' % (cat.get_id(), cat.get_id(),cat.get_name())
-    print '''<td><input type="button" onClick="removeCategory(%d,'%s')" value="remove" /></td>''' % (cat.get_id(),cat.get_name())
-    print '''</tr>'''
-print '''</tbody></table>'''
+    print('''<tr class="%d_cat_tr" id="%d_cat_tr"><td>%s</td>''' % (cat.get_id(), cat.get_id(),cat.get_name()))
+    print('''<td><input type="button" onClick="removeCategory(%d,'%s')" value="remove" /></td>''' % (cat.get_id(),cat.get_name()))
+    print('''</tr>''')
+print('''</tbody></table>''')
 
-print '''<br /><div id="new"><tr><td><input id='newCatName' type="text" size="10" value="" /></td><td><input type="button" onClick="addCategory()" value="add new" /></td>'''
-print '''</div>'''
+print('''<br /><div id="new"><tr><td><input id='newCatName' type="text" size="10" value="" /></td><td><input type="button" onClick="addCategory()" value="add new" /></td>''')
+print('''</div>''')
 
-print '''</body></html>'''
+print('''</body></html>''')

--- a/web/staff/op_tools/manage_distributors.py
+++ b/web/staff/op_tools/manage_distributors.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # manage_distributors.py
 # This page lets the user add new distributors as well as modify information about old ones
 
 import op_db_library as db
 
-print '''Content-Type: text/html\n\n'''
-print '''<html><head>
+print('''Content-Type: text/html\n\n''')
+print('''<html><head>
     <title>Open Produce Distributor Manager</title>
     <style type="text/css">
     * { font-family: sans-serif; font-size: 12px;}
@@ -22,7 +22,7 @@ print '''<html><head>
          function(data){
            if (data.indexOf('Error:') == -1){
                   $('.'+distid+'_dist_tr').remove();
-                  $('.'+distid+'_dist_tr', window.parent.main.document).remove();  
+                  $('.'+distid+'_dist_tr', window.parent.main.document).remove();
                   $('.'+distid+'_dist_option', window.parent.main.document).remove();
                  // there might be a better way to do this but I'm not sure
                   $('td:contains('+trim(data)+')', window.parent.main.document).each( function(){
@@ -35,17 +35,17 @@ print '''<html><head>
                            else {
                              $(thistd).html(data+' &nbsp;');
                            }
-                      
+
                        },'text');
                      }
                   });
-        
+
            }
            else{
               alert(data);
            }
           }, 'text');
-     } 
+     }
 
      function addDistributor() {
         var distname = $('#newDistName').val();
@@ -74,24 +74,24 @@ print '''<html><head>
 
     </script>
     </head>
-    '''
+    ''')
 
-print '''<body>
+print('''<body>
 <table border=0  cellspacing=2 cellpadding=0>
 <thead><tr>
 <th>Distributor</th>
 <th>Remove</th>
 </thead>
 <tbody id="distributors">
-'''
+''')
 
 for dist in db.get_distributors():
-    print '''<tr class="%d_dist_tr" id="%d_tr"><td>%s</td>''' % (dist.get_id(),dist.get_id(),dist.get_name())
-    print '''<td><input type="button" onClick="removeDistributor(%d)" value="remove" /></td>''' % (dist.get_id())
-    print '''</tr>'''
-print '''</tbody></table>'''
+    print('''<tr class="%d_dist_tr" id="%d_tr"><td>%s</td>''' % (dist.get_id(),dist.get_id(),dist.get_name()))
+    print('''<td><input type="button" onClick="removeDistributor(%d)" value="remove" /></td>''' % (dist.get_id()))
+    print('''</tr>''')
+print('''</tbody></table>''')
 
-print '''<br /><div id="new"><tr><td><input id='newDistName' type="text" size="10" value="" /></td><td><input type="button" onClick="addDistributor()" value="add new" /></td>'''
-print '''</div>'''
+print('''<br /><div id="new"><tr><td><input id='newDistName' type="text" size="10" value="" /></td><td><input type="button" onClick="addDistributor()" value="add new" /></td>''')
+print('''</div>''')
 
-print '''</body></html>'''
+print('''</body></html>''')

--- a/web/staff/op_tools/manage_items.py
+++ b/web/staff/op_tools/manage_items.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # manage_items.py
 # Patrick McQuighan
 # Tool for changing item names and stocked status and adding/removing distributors/categories/tax categories.
@@ -7,11 +7,11 @@ import op_db_library as db
 import item_display_form as idf
 import cgi
 import cgitb
-cgitb.enable() 
+cgitb.enable()
 
 def print_headers():
-    print '''Content-Type: text/html\n\n'''
-    print '''<html><head>
+    print('''Content-Type: text/html\n\n''')
+    print('''<html><head>
     <title>Open Produce Item Manager</title>
 
     <link rel="stylesheet" type="text/css" href="../../common/tools.css" />
@@ -33,7 +33,7 @@ function multiAddDist(){
            function(data){
               if(data.indexOf('Error:') == -1){   // update text
                 $.post('update_distributor_item.py', { action: 'query', item: id},
-                  function(data){ 
+                  function(data){
                      $('#'+id+'_dist').html(data + ' &nbsp; ');
                    }, 'text');
                }
@@ -50,7 +50,7 @@ function multiRemoveDist(){
            function(data){
               if(data.indexOf('Error:') == -1){   // update text
                 $.post('update_distributor_item.py', { action: 'query', item: id},
-                  function(data){  
+                  function(data){
                     $('#'+id+'_dist').html(data + ' &nbsp; ');
                   }, 'text');
                }
@@ -128,7 +128,7 @@ function updateDistributorItemInfo(itemid, d_id){
    cs = $('#'+itemid+'_'+d_id+'_caseSize').val();
    p = $('#'+itemid+'_'+d_id+'_price').val();
    di = $('#'+itemid+'_'+d_id+'_distItemId').val();
-   
+
    $.post('update_distributor_item.py', { action: 'update', item: itemid, distid: d_id, distitemid: di, price: p, casesize: cs, caseunit: cu },
        function () {alert('Update succesful');}, 'text');
 
@@ -175,7 +175,7 @@ $(document).ready(function() {
                function(data){
                   name_box.disabled = false;
                   if(data.indexOf('Error:') == -1) {
-                     $(name_box).removeClass('default').removeClass('submitting').addClass('complete');      
+                     $(name_box).removeClass('default').removeClass('submitting').addClass('complete');
                   }
                   else { alert(data);}
                }, 'text');
@@ -197,7 +197,7 @@ $(document).ready(function() {
                function(data){
                   bc_box.disabled = false;
                   if(data.indexOf('Error:') == -1) {
-                      bc_box.id = itemid + "_" + newbc + "_" + "bc";                      
+                      bc_box.id = itemid + "_" + newbc + "_" + "bc";
                       $(bc_box).removeClass('default').removeClass('submitting').addClass('complete');
                   }
                   else { alert(data);}
@@ -208,45 +208,45 @@ $(document).ready(function() {
 
 });
 </script>
-'''
+''')
     idf.print_javascript()
-    print '''</head>'''
+    print('''</head>''')
 
 def print_multi_add():
-    print '''<div class="fixed">'''
+    print('''<div class="fixed">''')
 
-    print '''<select class="multi_dist" id="multi_dist">'''
+    print('''<select class="multi_dist" id="multi_dist">''')
     for dist in db.get_distributors():
-        print '''<option class="%d_dist_option" value="%d"> %s </option>''' % (dist.get_id(),dist.get_id(),dist)
-    print '''</select>'''
-    print '''<button type="button" onClick="multiAddDist()">Add Dist</button>'''
-    print '''<button type="button" onClick="multiRemoveDist()">Remove Dist</button>'''
+        print('''<option class="%d_dist_option" value="%d"> %s </option>''' % (dist.get_id(),dist.get_id(),dist))
+    print('''</select>''')
+    print('''<button type="button" onClick="multiAddDist()">Add Dist</button>''')
+    print('''<button type="button" onClick="multiRemoveDist()">Remove Dist</button>''')
 
-    print '''<select class="multi_category" id="multi_category">'''
+    print('''<select class="multi_category" id="multi_category">''')
     for cat in db.get_categories():
-        print '''<option class="%d_cat_option" value="%d"> %s </option>''' % (cat.get_id(),cat.get_id(),cat)
-    print '''</select>'''
-    print '''<button type="button" onClick="multiAddCategory()">Add Category</button>'''
-    print '''<button type="button" onClick="multiRemoveCategory()">Remove Category</button>'''
-    
-    print '''<select class="addTaxCat" id="multi_tax_category">'''
-    for taxcat in db.get_tax_categories():
-        print '''<option class="%d_taxcat_option" value="%d"> %s </option>''' % (taxcat.get_id(),taxcat.get_id(),taxcat)
-    print '''</select>'''
-    print '''<button type="button" onClick="multiSetTaxCategory()">Set TaxCat</button>'''
+        print('''<option class="%d_cat_option" value="%d"> %s </option>''' % (cat.get_id(),cat.get_id(),cat))
+    print('''</select>''')
+    print('''<button type="button" onClick="multiAddCategory()">Add Category</button>''')
+    print('''<button type="button" onClick="multiRemoveCategory()">Remove Category</button>''')
 
-    print '''<button type="button" onClick="uncheckAllMulti()">Uncheck All Items </button>'''
-    print '''</div>'''
+    print('''<select class="addTaxCat" id="multi_tax_category">''')
+    for taxcat in db.get_tax_categories():
+        print('''<option class="%d_taxcat_option" value="%d"> %s </option>''' % (taxcat.get_id(),taxcat.get_id(),taxcat))
+    print('''</select>''')
+    print('''<button type="button" onClick="multiSetTaxCategory()">Set TaxCat</button>''')
+
+    print('''<button type="button" onClick="uncheckAllMulti()">Uncheck All Items </button>''')
+    print('''</div>''')
 
 def main():
     form = cgi.FieldStorage()
     idf.init(form,discontinued=True,distributors=True,categories=True)
     print_headers()
 
-    print '''
+    print('''
 
-<body>'''
-    print '''
+<body>''')
+    print('''
 <div class="key">
          Key:
 	      <span class="na"> very negative (produce, etc.) </span>
@@ -258,15 +258,15 @@ def main():
          <div>Click distributor to change info there. + or - signs add or remove the distributor respectively.  To change any of the other columns make your modifications and click the word update at the end of the row.</div>
          <div>Note that this currently only supports SINGLE barcodes, and needs to be redone (probably in a similar manner to categories etc) to support multiple </div>
          <div>The M-Edit checkbox allows you to add/remove things to multiple items at once </div>
-         <div style="clear: both; height: 15px;"> </div>'''
-    print '''</body></html>'''
-    
+         <div style="clear: both; height: 15px;"> </div>''')
+    print('''</body></html>''')
+
     print_multi_add()
-    print '''<form name="options" action="manage_items.py" method="get">'''
+    print('''<form name="options" action="manage_items.py" method="get">''')
     options = idf.print_form()
-    print '''<input type="submit" value="Change options" /> </form>'''
-    print '''<br> <br>'''
-    print '''<table border=0 id="main" class="sortable" cellspacing=0 cellpadding=0>
+    print('''<input type="submit" value="Change options" /> </form>''')
+    print('''<br> <br>''')
+    print('''<table border=0 id="main" class="sortable" cellspacing=0 cellpadding=0>
              <thead class="col-header">
              <th class="th">M-Edit</th>
              <th class="th">Name</th>
@@ -276,46 +276,46 @@ def main():
              <th class="th">Category</th>
              <th class="th">Tax Category</th>
              <th class="th">Stocked</th>
-             </thead><tbody id=\"item-stats\">\n'''
-    
+             </thead><tbody id=\"item-stats\">\n''')
+
     for i,item in enumerate(db.get_items(**options)):
         count = item.get_count()
         item_id = item.get_id()
         day14 = db.get_sales_in_range(item_id,14)
 
         if count < -10.0:
-            print '''<tr id="tr_%d" class="na" title="%d">''' % (item_id,day14)
+            print('''<tr id="tr_%d" class="na" title="%d">''' % (item_id,day14))
         elif count < 0.0:
-            print '''<tr id="tr_%d" class="bad" title="%d">''' % (item_id,day14)
+            print('''<tr id="tr_%d" class="bad" title="%d">''' % (item_id,day14))
         elif count < 1.0:
-            print '''<tr id="tr_%d" class="out" title="%d">''' % (item_id,day14)
+            print('''<tr id="tr_%d" class="out" title="%d">''' % (item_id,day14))
         elif count < day14:
-            print '''<tr id="tr_%d" class="low" title="%d">''' % (item_id,day14)
+            print('''<tr id="tr_%d" class="low" title="%d">''' % (item_id,day14))
         else:
-            print '<tr id="tr_%d" title="%d">' % (item_id,day14)
-        
-        print '''<div class='div_%d'>''' % (item_id)
-        print '''<td> <input class="multi" type="checkbox" id="%d" /></td>''' % (item_id,)
-	print '''<td><input type="text" class="itemname" id="%d_name" value="%s" />[%s]''' % (item.get_id(), item.get_name(),item.get_size_str())
-        print '''<td id="%d_dist" style='border-left: 1px solid #999; border-right: 1px solid #999; padding-left: 1em;'> %s &nbsp;</td>''' % (item_id, item.get_distributors_str())
+            print('<tr id="tr_%d" title="%d">' % (item_id,day14))
 
-	print '''<td style='text-align: center;'> <a href="%s" onclick="window.open(this.href,'_blank'); return false;">%d </a></td>''' % (db.get_item_info_page_link(item_id),item_id)
+        print('''<div class='div_%d'>''' % (item_id))
+        print('''<td> <input class="multi" type="checkbox" id="%d" /></td>''' % (item_id,))
+        print('''<td><input type="text" class="itemname" id="%d_name" value="%s" />[%s]''' % (item.get_id(), item.get_name(),item.get_size_str()))
+        print('''<td id="%d_dist" style='border-left: 1px solid #999; border-right: 1px solid #999; padding-left: 1em;'> %s &nbsp;</td>''' % (item_id, item.get_distributors_str()))
+
+        print('''<td style='text-align: center;'> <a href="%s" onclick="window.open(this.href,'_blank'); return false;">%d </a></td>''' % (db.get_item_info_page_link(item_id),item_id))
         barcode = item.get_first_barcode()
         if barcode != None:
-            print '''<td> <input size="16" type="text" class="itembarcode" id="%d_%s_bc" value="%s" /> &nbsp;</td>''' % (item_id,barcode.get_barcode(), barcode.get_barcode())
+            print('''<td> <input size="16" type="text" class="itembarcode" id="%d_%s_bc" value="%s" /> &nbsp;</td>''' % (item_id,barcode.get_barcode(), barcode.get_barcode()))
         else:
-            print '''<td> <input size="16" type="text" class="itembarcode" id="%d_%s_bc" value="%s" /> &nbsp;</td>''' % (item_id, 'None', 'None')
-        print '''<td style='border-left: 1px solid #999; border-right: 1px solid #999;' id='%d_cat'> %s &nbsp;</td>''' % (item_id, item.get_categories_str(), )
-        print '''<td style='border-right: 1px solid #999;' id='%d_tax'> %s &nbsp;</td>''' % (item_id, str(item.get_tax_category()), )
+            print('''<td> <input size="16" type="text" class="itembarcode" id="%d_%s_bc" value="%s" /> &nbsp;</td>''' % (item_id, 'None', 'None'))
+        print('''<td style='border-left: 1px solid #999; border-right: 1px solid #999;' id='%d_cat'> %s &nbsp;</td>''' % (item_id, item.get_categories_str(), ))
+        print('''<td style='border-right: 1px solid #999;' id='%d_tax'> %s &nbsp;</td>''' % (item_id, str(item.get_tax_category()), ))
         if not item.get_is_discontinued():
-            print '''<td><input type="checkbox" id="%d_isStocked" onClick="discontinueItem(this)" checked /> </td>''' % (item_id,)
+            print('''<td><input type="checkbox" id="%d_isStocked" onClick="discontinueItem(this)" checked /> </td>''' % (item_id,))
         else:
-            print '''<td><input type="checkbox" id="%d_isStocked"  onClick="discontinueItem(this)"/> </td>''' % (item_id,)                                                                             
-        print '''</div>'''
-        print '''</tr>\n'''
+            print('''<td><input type="checkbox" id="%d_isStocked"  onClick="discontinueItem(this)"/> </td>''' % (item_id,))
+        print('''</div>''')
+        print('''</tr>\n''')
 
-    print '''</tbody></table>\n'''
-    print '''</body></html>'''
+    print('''</tbody></table>\n''')
+    print('''</body></html>''')
 
 
 if __name__ == "__main__":

--- a/web/staff/op_tools/manage_prices.py
+++ b/web/staff/op_tools/manage_prices.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # manage_prices.py
 # Patrick McQuighan
 
@@ -11,26 +11,26 @@ cgitb.enable()
 colspan = 13   # number of columns for a given item's row, i.e. doesn't include PriceID or OP Price fields
 # NOTE  this value is hardcoded into add_items_js.py
 def print_headers():
-    print '''Content-Type: text/html\n\n'''
-    print '''<html><head>
+    print('''Content-Type: text/html\n\n''')
+    print('''<html><head>
     <title>Open Produce Price Manager</title>
 
     <link rel="stylesheet" type="text/css" href="../../common/tools.css" />
     <script type="text/javascript" src="../../common/jquery-1.3.2.min.js"></script>\n
     <script type="text/javascript" src="../../common/sorttable.js"></script>\n
     <script type="text/javascript" src="../../common/fix_table_headers.js"></script>
-<script type="text/javascript">'''
+<script type="text/javascript">''')
     # The following is just to remove whitespace and &nbsp's from stuff
-    print '''
+    print('''
     function trim(str) {
        return str.replace(/^[\s]+/g,'').replace(/[\s]+$/g,'');
-    }'''
+    }''')
     # The following array is needed so that the when an item is split it will have the dropdown to change sale units
-    print '''units = new Array();'''
+    print('''units = new Array();''')
     for i,unit in enumerate(db.get_units()):
-        print '''units[%d] = '%s';''' % (i, str(unit))
+        print('''units[%d] = '%s';''' % (i, str(unit)))
 
-    print '''
+    print('''
     function handlePriceChange(e){
 		if (e.which == 13) {
                      var p_id = parseInt(this.id);
@@ -57,7 +57,7 @@ def print_headers():
          function(data){
          }, 'text');
    }
-  
+
     function handleGroupChange(e){
                 if (e.which == 13) {
                    var item = parseInt(this.id);
@@ -66,7 +66,7 @@ def print_headers():
                      function(data){
                        if(data.indexOf('Error:') == -1){
                        // data contains old_price_id, [1] is the number of items with a given price
-                         data = data.split(',');    
+                         data = data.split(',');
                          updateRows(item,data,newid);
                        }
                        else{
@@ -95,10 +95,10 @@ def print_headers():
 					    $('#'+id+'_amt').html(data);
                                         }
                                         day14 = parseFloat($('#tr_'+id).attr('title'))
-                                         
+
                                     }
 				}, 'text');
-                         
+
 		}
     }
 
@@ -143,7 +143,7 @@ def print_headers():
                          }
                          else { alert(data);}
                       }, 'text');
-            } 
+            }
     }
 
     function handleCaseCostChange(e){
@@ -161,7 +161,7 @@ def print_headers():
                       function(data){
                          ditem_box.disabled = false;
                          if(data.indexOf('Error:') == -1) {
-                             $(ditem_box).removeClass('default').removeClass('submitting').addClass('complete'); 
+                             $(ditem_box).removeClass('default').removeClass('submitting').addClass('complete');
                              updateMargins(price);
                          }
                          else { alert(data);}
@@ -184,14 +184,14 @@ def print_headers():
            }
            newrow += '</select></td>';
 
-           newrow += '<td ''',
-    print '''colspan="%d" class="td"> <table id="'+newid+'_table" cellspacing=0 cellpadding=0></table></td></tr>' ''' % (colspan)
-    print '''
+           newrow += '<td ''', end='')
+    print('''colspan="%d" class="td"> <table id="'+newid+'_table" cellspacing=0 cellpadding=0></table></td></tr>' ''' % (colspan))
+    print('''
            $('#main').append(newrow);
            $('.price').keypress(handlePriceChange);
          }
          $('#'+newid+'_table').append($('.'+item+'_tr'));
-                        
+
         updateMargins(newid);
 
         if (parseInt(data[1]) == 0){
@@ -208,10 +208,10 @@ def print_headers():
                else { alert(data);}
             }, 'text');
     }
- 
+
     function updateMargins(price){
         $.post('update_prices.py', {action: 'query', price_id: price},
-            function(data){                                 
+            function(data){
                if(data.indexOf('Error:') != -1){
                    alert(data);
                }
@@ -228,7 +228,7 @@ def print_headers():
                       } else if(margin <= 30) {
                          $(tagPrefix+'margin').attr('class','mid');
                       } else{
-                         $(tagPrefix+'margin').attr('class','good');                 
+                         $(tagPrefix+'margin').attr('class','good');
                       }
                    }
                }
@@ -242,7 +242,7 @@ def print_headers():
           function(data){
             if(data.indexOf('Error:') == -1){
                // data contains old_price_id, [1] is the number of items with a given price
-               data = data.split(',');    
+               data = data.split(',');
                newid = parseInt(data[3]);
                updateRows(item, data, newid);
             }
@@ -261,7 +261,7 @@ def print_headers():
               width = $('#item-stats').children(':first').children().eq(idx).css('width');
             }
             else {
-              // Since we have a table within the first table (at idx 3) we need to get a child from that table 
+              // Since we have a table within the first table (at idx 3) we need to get a child from that table
               width = $('.inner_table:first').children(':first').children().eq(idx-3).css('width');
             }
             $(th).css('width',width);
@@ -278,29 +278,29 @@ def print_headers():
 
 
 </script>
-'''
+''')
     idf.print_javascript()
-    print '''
-    </head>'''
+    print('''
+    </head>''')
 
 def main():
     form = cgi.FieldStorage()
     idf.init(form,discontinued=True,distributors=True,categories=True)
     print_headers()
-    print '''
-<body>'''
-    print '''
+    print('''
+<body>''')
+    print('''
          <div>Click table headers to sort</div>
          <div>To change a price, enter the new price in the text field and hit ENTER </div>
          <div>To change an item's price group, enter the new group and hit ENTER </div>
          <div>To split an item from the given group click the 'split' button. It will be given a new price_id </div>
          <div>To log a delivery select the appropriate distributor from the dropdown, type in the number delievered (positive or negative integer) and press ENTER </div>
-         <div style="clear: both; height: 15px;"> </div>'''
-    print '''<form name="options" action="manage_prices.py" method="get">'''
+         <div style="clear: both; height: 15px;"> </div>''')
+    print('''<form name="options" action="manage_prices.py" method="get">''')
     options = idf.print_form()
-    print '''<input type="submit" value="Change options" /> </form>'''
-    print '''<br><br>'''
-    print '''<table border=0 id="main" class="sortable" cellspacing=0 cellpadding=0>
+    print('''<input type="submit" value="Change options" /> </form>''')
+    print('''<br><br>''')
+    print('''<table border=0 id="main" class="sortable" cellspacing=0 cellpadding=0>
              <thead class="col-header">
              <th class="th">Price ID </th>
              <th class="th">OP Price</th>
@@ -319,8 +319,8 @@ def main():
              <th class="th">Change P_ID</th>
              <th class="th">Split</th>
              <th class="th">Stocked</th>
-             </thead><tbody id="item-stats">\n'''
-    
+             </thead><tbody id="item-stats">\n''')
+
     cur_price = -1
     cur_item = -1
 
@@ -332,40 +332,40 @@ def main():
         if cur_price != price_id:
             if cur_price != -1:
                 # end previous row
-                print '</tbody>'
-                print '</table></td></tr>'
-            print '<tr class="color-row" id="%d_price"><td class="td">%d</td><td class="td">$<input type="text" class="price" id="%d_price_input" size="3" value="%.2f"></input></td>'  % (price_id, price_id, price_id, price.get_unit_cost())
-        
-            print '''<td class="td"> <select class="saleunit" id="%d_sale_unit" onChange="setPriceSaleUnit(%d)">''' % (price_id,price_id)
+                print('</tbody>')
+                print('</table></td></tr>')
+            print('<tr class="color-row" id="%d_price"><td class="td">%d</td><td class="td">$<input type="text" class="price" id="%d_price_input" size="3" value="%.2f"></input></td>'  % (price_id, price_id, price_id, price.get_unit_cost()))
+
+            print('''<td class="td"> <select class="saleunit" id="%d_sale_unit" onChange="setPriceSaleUnit(%d)">''' % (price_id,price_id))
             for unit in units:
-                print '''<option value="%d"''' % (unit[0],)
+                print('''<option value="%d"''' % (unit[0],))
                 if unit[0] == price.get_sale_unit_id():
-                    print ''' selected>'''
+                    print(''' selected>''')
                 else:
-                    print '''>'''
-                print unit[1], ''' </option>'''
+                    print('''>''')
+                print(unit[1], ''' </option>''')
 
-            print '''</select></td>'''
+            print('''</select></td>''')
 
-            print'<td colspan="%d" class="td"><table id="%d_table" cellspacing=0 cellpadding=0>' % (colspan,price_id)
-            print '<tbody class="inner_table">'
+            print('<td colspan="%d" class="td"><table id="%d_table" cellspacing=0 cellpadding=0>' % (colspan,price_id))
+            print('<tbody class="inner_table">')
             cur_price = price_id
-        print '<tr class="%d_tr">' % (item_id,)
-        
+        print('<tr class="%d_tr">' % (item_id,))
+
         if cur_item != item_id:
             item_dist_count = item.get_distributor_count()
-            print '''<td rowspan='%s' id='%d_td' width='400' style='padding-left: 1em;'> %s </td>''' %  (item_dist_count, item_id, str(item))
-            print '''<td rowspan='%s' width='80'> <a href='%s' onclick="window.open(this.href,'_blank'); return false;">%d</a> </td>''' % (item_dist_count,db.get_item_info_page_link(item_id),item_id)
-            print '''<td rowspan='%s' width='80' id="%d_amt"> %d </td>''' % (item_dist_count,item_id,item.get_count())
-            print '''<td rowspan="%d" width='100'><input class="amt" id="%d_in" name="%d_in" size="2"/>''' % (item_dist_count,item_id, item_id)
-            print '''<select id="%d_dist_in" name="%d_dist_in">''' % (item_id, item_id)
+            print('''<td rowspan='%s' id='%d_td' width='400' style='padding-left: 1em;'> %s </td>''' %  (item_dist_count, item_id, str(item)))
+            print('''<td rowspan='%s' width='80'> <a href='%s' onclick="window.open(this.href,'_blank'); return false;">%d</a> </td>''' % (item_dist_count,db.get_item_info_page_link(item_id),item_id))
+            print('''<td rowspan='%s' width='80' id="%d_amt"> %d </td>''' % (item_dist_count,item_id,item.get_count()))
+            print('''<td rowspan="%d" width='100'><input class="amt" id="%d_in" name="%d_in" size="2"/>''' % (item_dist_count,item_id, item_id))
+            print('''<select id="%d_dist_in" name="%d_dist_in">''' % (item_id, item_id))
             for d in item.get_distributors():
-                print '''<option value="%s"> %s </option>''' % (d.get_dist_id(),d.get_distributor())
-            print '''</select>'''
-            print '''</td>\n'''
-        
-        print '''<td width="100"> %s </td>''' % (dist,)
-        print '''<td width="100"> <input class="ditemid" size="10" value="%s" id="%d_%d_ditemid" /> </td>''' % (dist_item.get_dist_item_id(),item.get_id(), dist.get_id())
+                print('''<option value="%s"> %s </option>''' % (d.get_dist_id(),d.get_distributor()))
+            print('''</select>''')
+            print('''</td>\n''')
+
+        print('''<td width="100"> %s </td>''' % (dist,))
+        print('''<td width="100"> <input class="ditemid" size="10" value="%s" id="%d_%d_ditemid" /> </td>''' % (dist_item.get_dist_item_id(),item.get_id(), dist.get_id()))
 
         each_cost = dist_item.get_each_cost()
         op_price = item.get_price()
@@ -376,31 +376,31 @@ def main():
         else:
             margin = 100
 
-	print '''<td width="100">$<input class="casecost" size="6" value="%.2f" id="%d_%d_%d_casecost" /></td>''' % (dist_item.get_wholesale_price(), item.get_id(), dist.get_id(), price_id)
-        print '''<td width="80" ><input class="casesize" size="5" value="%.2f" id="%d_%d_%d_casesize"/> </td>''' % (dist_item.get_case_size(), item.get_id(), dist.get_id(), price_id)
-        print '''<td width="80">%s </td>''' % (dist_item.get_case_unit(),)
+        print('''<td width="100">$<input class="casecost" size="6" value="%.2f" id="%d_%d_%d_casecost" /></td>''' % (dist_item.get_wholesale_price(), item.get_id(), dist.get_id(), price_id))
+        print('''<td width="80" ><input class="casesize" size="5" value="%.2f" id="%d_%d_%d_casesize"/> </td>''' % (dist_item.get_case_size(), item.get_id(), dist.get_id(), price_id))
+        print('''<td width="80">%s </td>''' % (dist_item.get_case_unit(),))
 
-	print '''<td width="80" id="%d_%d_each">$%.2f </td>''' % (item_id,dist.get_id(),each_cost)
+        print('''<td width="80" id="%d_%d_each">$%.2f </td>''' % (item_id,dist.get_id(),each_cost))
         if margin <= 20:
-            print '''<td width="80" class="bad" id="%d_%d_margin"> %.0f%% &nbsp;</td>''' % (item_id,dist.get_id(), margin)
+            print('''<td width="80" class="bad" id="%d_%d_margin"> %.0f%% &nbsp;</td>''' % (item_id,dist.get_id(), margin))
         elif margin <= 30:
-            print '''<td width="80" class="mid" id="%d_%d_margin"> %.0f%% &nbsp; </td>''' % (item_id,dist.get_id(), margin)
+            print('''<td width="80" class="mid" id="%d_%d_margin"> %.0f%% &nbsp; </td>''' % (item_id,dist.get_id(), margin))
         else:
-            print '''<td width="80" class="good" id="%d_%d_margin"> %.0f%% &nbsp; </td>''' % (item_id,dist.get_id(), margin)
+            print('''<td width="80" class="good" id="%d_%d_margin"> %.0f%% &nbsp; </td>''' % (item_id,dist.get_id(), margin))
 
         if cur_item != item_id:
-            print '''<td rowspan='%s' width="100"><input class="group" id="%d_group" type="text" size="3"></input></td>''' % (item_dist_count,item_id)
-            print '''<td rowspan='%s' width="80"><div onClick="split(%d)">split</div></td>''' % (item_dist_count,item_id)
+            print('''<td rowspan='%s' width="100"><input class="group" id="%d_group" type="text" size="3"></input></td>''' % (item_dist_count,item_id))
+            print('''<td rowspan='%s' width="80"><div onClick="split(%d)">split</div></td>''' % (item_dist_count,item_id))
             if not item.get_is_discontinued():
-                print '''<td><input type="checkbox" id="%d_isStocked" onClick="discontinueItem(this)" checked /> </td>''' % (item_id,)
+                print('''<td><input type="checkbox" id="%d_isStocked" onClick="discontinueItem(this)" checked /> </td>''' % (item_id,))
             else:
-                print '''<td><input type="checkbox" id="%d_isStocked"  onClick="discontinueItem(this)"/> </td>''' % (item_id,)                                             
+                print('''<td><input type="checkbox" id="%d_isStocked"  onClick="discontinueItem(this)"/> </td>''' % (item_id,))
             cur_item = item_id
-        print '''</tr>\n'''
+        print('''</tr>\n''')
 
-    print '</table></td></tr>'
-    print '''</tbody></table>\n'''
-    print '''</body></html>'''
+    print('</table></td></tr>')
+    print('''</tbody></table>\n''')
+    print('''</body></html>''')
 
 
 if __name__ == "__main__":

--- a/web/staff/op_tools/manage_tax_categories.py
+++ b/web/staff/op_tools/manage_tax_categories.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # manage_tax_categories.py
 # This page lets the user add new tax categories as well as modify information about old ones
 
 import op_db_library as db
 
-print '''Content-Type: text/html\n\n'''
-print '''<html><head>
+print('''Content-Type: text/html\n\n''')
+print('''<html><head>
     <title>Open Produce Tax Category Manager</title>
     <style type="text/css">
       * { font-family: sans-serif; font-size: 12px;}
@@ -26,10 +26,10 @@ print '''<html><head>
            // there might be a better way to do this but I'm not sure
            $('td[onClick*=editTaxCategory]:contains('+name+')', window.parent.main.document).html('None');
          }, 'text');
-    } 
+    }
     function updateTaxCategory(id,taxcatname) {
       var taxrate = $('#'+id+'_tax_rate').val();
-      $.post('update_tax_categories.py', {taxcatid: id, action: 'update', rate: taxrate}, 
+      $.post('update_tax_categories.py', {taxcatid: id, action: 'update', rate: taxrate},
          function(data){
             if(data.indexOf("Error:") == -1){
                 $('td[onClick*=editTaxCategory]:contains('+taxcatname+')', window.parent.main.document).html(data);
@@ -72,9 +72,9 @@ print '''<html><head>
 
    </script>
     </head>
-    '''
+    ''')
 
-print '''<body>
+print('''<body>
 <table border=0  cellspacing=2 cellpadding=0>
 <thead><tr>
 <th>Tax Category</th>
@@ -83,19 +83,19 @@ print '''<body>
 <th>Remove</th>
 </thead>
 <tbody id="taxcategories">
-'''
+''')
 
 for tax in db.get_tax_categories():
-    print '''<tr class="%d_taxcat_tr" id="%d_taxcat_tr"><td>%s</td>''' % (tax.get_id(), tax.get_id(),tax.get_name())
-    print '''<td><input type="text" id="%d_tax_rate" value="%.2f" size=5>''' % (tax.get_id(), tax.get_rate()*100)
-    print '''<td><input type="button" onClick="updateTaxCategory(%d,'%s')" value="update" /></td>''' % (tax.get_id(),tax.get_name())
-    print '''<td><input type="button" onClick="removeTaxCategory(%d,'%s')" value="remove" /></td>''' % (tax.get_id(),tax.get_name())
-    print '''</tr>'''
-print '''</tbody></table>'''
+    print('''<tr class="%d_taxcat_tr" id="%d_taxcat_tr"><td>%s</td>''' % (tax.get_id(), tax.get_id(),tax.get_name()))
+    print('''<td><input type="text" id="%d_tax_rate" value="%.2f" size=5>''' % (tax.get_id(), tax.get_rate()*100))
+    print('''<td><input type="button" onClick="updateTaxCategory(%d,'%s')" value="update" /></td>''' % (tax.get_id(),tax.get_name()))
+    print('''<td><input type="button" onClick="removeTaxCategory(%d,'%s')" value="remove" /></td>''' % (tax.get_id(),tax.get_name()))
+    print('''</tr>''')
+print('''</tbody></table>''')
 
-print '''<br /><div id="new"><tr><td><input id='newTaxCatName' type="text" size="10" value="" /></td>
+print('''<br /><div id="new"><tr><td><input id='newTaxCatName' type="text" size="10" value="" /></td>
 <td><input type="text" id="newTaxCatRate" size=5>
-<td><input type="button" onClick="addTaxCategory()" value="add new" /></td>'''
-print '''</div>'''
+<td><input type="button" onClick="addTaxCategory()" value="add new" /></td>''')
+print('''</div>''')
 
-print '''</body></html>'''
+print('''</body></html>''')

--- a/web/staff/op_tools/merge_confirmation.py
+++ b/web/staff/op_tools/merge_confirmation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # merge_confirmation.py
 # Patrick McQuighan
 # This is the confirmation page displaying all information about the two items to be merged
@@ -10,20 +10,20 @@ import cgitb
 cgitb.enable()
 
 def print_headers():
-    print '''Content-Type: text/html
+    print('''Content-Type: text/html
 
 <html>
  <head>
   <title>Open Produce Item Merger </title>
-  <link rel="stylesheet" type="text/css" href="../../common/tools.css" /> 
+  <link rel="stylesheet" type="text/css" href="../../common/tools.css" />
   <script type="text/javascript" src="../../common/jquery-1.3.2.min.js"></script>\n
   <script type="text/javascript">
     function merge(old_item, into_item) {
-      $.post("merge_items.py", {old : old_item, into : into_item, barcodes : $('#m_barcodes').attr('checked'), 
-                                deliveries : $('#m_deliveries').attr('checked'), dist_items : $('#m_dist_items').attr('checked'), sales : $('#m_sales').attr('checked')}, 
+      $.post("merge_items.py", {old : old_item, into : into_item, barcodes : $('#m_barcodes').attr('checked'),
+                                deliveries : $('#m_deliveries').attr('checked'), dist_items : $('#m_dist_items').attr('checked'), sales : $('#m_sales').attr('checked')},
         function(data){
           if (data.indexOf('Error:') != -1) {
-            alert(data); 
+            alert(data);
           }
           else {
             alert("Successfully merged "+old_item+" into "+into_item+".\\nWill redirect to the new item's info page when you click ok.");
@@ -33,10 +33,10 @@ def print_headers():
     }
   </script>
  </head>
- <body>'''
+ <body>''')
 
 def print_tables (name1,list1,name2,list2):
-    print '''
+    print('''
 <table>
   <thead>
    <tr>
@@ -46,70 +46,70 @@ def print_tables (name1,list1,name2,list2):
    <tr>
    <td class="td_rborder">%s</td><td>%s</td>
    </tr>
-  ''' % (name1, name2)
+  ''' % (name1, name2))
     len1 = len(list1)
     len2 = len(list2)
     max_val = max(len1, len2)
-    
+
     for i in range(max_val):
-        print '<tr>'
+        print('<tr>')
         if i < len1:
-            print '<td class="td_rborder">%s</td>' % (list1[i])
+            print('<td class="td_rborder">%s</td>' % (list1[i]))
         else:
-            print '<td class="td_rborder">&nbsp;</td>'
+            print('<td class="td_rborder">&nbsp;</td>')
 
         if i < len2:
-            print '<td>%s</td>' % (list2[i])
+            print('<td>%s</td>' % (list2[i]))
         else:
-            print '<td>&nbsp;</td>'
+            print('<td>&nbsp;</td>')
 
-        print '</tr>'
-    print '''</table> '''
+        print('</tr>')
+    print('''</table> ''')
 
 def main():
     print_headers()
     form = cgi.FieldStorage()
     if 'old' not in form or 'into' not in form:
-        print 'Error: You need to include the OLD item id and the item id it is being merged INTO'
-        print '''Use the interface on <a href='item_info.py'>item_info.py</a> to do this'''
+        print('Error: You need to include the OLD item id and the item id it is being merged INTO')
+        print('''Use the interface on <a href='item_info.py'>item_info.py</a> to do this''')
     else:
         old_item_id = int(form.getvalue('old'))
         into_item_id = int(form.getvalue('into'))
         if not db.is_item(old_item_id):
-            print 'Item %d not found.' % (old_item_id)
+            print('Item %d not found.' % (old_item_id))
             sys.exit(0)
         if not db.is_item(into_item_id):
-            print 'Item %d not found.' % (into_item_id)
+            print('Item %d not found.' % (into_item_id))
             sys.exit(0)
         old_item = db.get_item(old_item_id)
         into_item = db.get_item(into_item_id)
         old_name = old_item.get_name()
         into_name = into_item.get_name()
-        print '''<b>%s</b> (SKU: %d) will be REMOVED from the database.<br />''' % (old_item,old_item_id)
-        print '''It will be merged INTO <b>%s</b> (SKU: %d).<br />''' % (into_item, into_item_id)
-        print '''Note: There is currently no way to undo the merge operation.<br />'''
-        print '''Additonally, if the merge results in the item having multiple entries for a given distributor the display in catalog.py will be wonky.  This will be corrected soon. Everything will display correctly in the item's item_info.py page so use that instead.<br /><br />'''
+        print('''<b>%s</b> (SKU: %d) will be REMOVED from the database.<br />''' % (old_item,old_item_id))
+        print('''It will be merged INTO <b>%s</b> (SKU: %d).<br />''' % (into_item, into_item_id))
+        print('''Note: There is currently no way to undo the merge operation.<br />''')
+        print('''Additonally, if the merge results in the item having multiple entries for a given distributor the display in catalog.py will be wonky.  This will be corrected soon. Everything will display correctly in the item's item_info.py page so use that instead.<br /><br />''')
 
-        print '''<u>Current Barcodes:</u>'''
+        print('''<u>Current Barcodes:</u>''')
         print_tables(old_name, old_item.get_barcodes(), into_name, into_item.get_barcodes())
-        print '<br />'
-        print '''<u>Current Distributor Item Info:</u>'''
+        print('<br />')
+        print('''<u>Current Distributor Item Info:</u>''')
         print_tables(old_name, old_item.get_distributor_items(), into_name, into_item.get_distributor_items())
-        print '<br />'
+        print('<br />')
 
-        print '''The following options control whether certain data about <b>%s</b> will be ADDED to <b>%s</b> <br />''' % (old_name, into_name)
+        print('''The following options control whether certain data about <b>%s</b> will be ADDED to <b>%s</b> <br />''' % (old_name, into_name))
 
-        print '''Merge barcodes: <input type="checkbox" id="m_barcodes" /> <br />'''
-        print '''Merge delivery records: <input type="checkbox" id="m_deliveries" checked /><br />'''
-        print '''Merge distributor item info: <input type="checkbox" id="m_dist_items" checked /><br />'''
-        print '''Merge sales data (Only Steven should change this option!): <input type="checkbox" id="m_sales" checked /><br />'''
-        print '''<br />'''
-        print '''The count and last_manual_count for the old item will disappear and not affect the count/last_manual_count of the item it is being merged into.  However, the count of the merged item may change due to the sales/deliveries from the old item.'''
-        print '''<br />'''
-        print '''<button type="button" onClick="merge(%d,%d)">Merge</button> ''' % (old_item_id, into_item_id)
-    print '''
+        print('''Merge barcodes: <input type="checkbox" id="m_barcodes" /> <br />''')
+        print('''Merge delivery records: <input type="checkbox" id="m_deliveries" checked /><br />''')
+        print('''Merge distributor item info: <input type="checkbox" id="m_dist_items" checked /><br />''')
+        print('''Merge sales data (Only Steven should change this option!): <input type="checkbox" id="m_sales" checked /><br />''')
+        print('''<br />''')
+        print('''The count and last_manual_count for the old item will disappear and not affect the count/last_manual_count of the item it is being merged into.  However, the count of the merged item may change due to the sales/deliveries from the old item.''')
+        print('''<br />''')
+        print('''<button type="button" onClick="merge(%d,%d)">Merge</button> ''' % (old_item_id, into_item_id))
+    print('''
  </body>
-</html>'''
+</html>''')
 
 if __name__ == "__main__":
     main()

--- a/web/staff/op_tools/merge_items.py
+++ b/web/staff/op_tools/merge_items.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # merge_items.py
 # Patrick McQuighan
 # This file actually merges two item ids based on a set of given options
@@ -7,10 +7,10 @@ import op_db_library as db
 import smtplib
 import cgi
 
-print '''Content-type: text/plain\n'''
+print('''Content-type: text/plain\n''')
 form = cgi.FieldStorage()
 if 'old' not in form or 'into' not in form or 'barcodes' not in form or 'deliveries' not in form or 'dist_items' not in form or 'sales' not in form:
-    print 'Error: invalid arguments.'
+    print('Error: invalid arguments.')
 else:
     old_item_id = int(form.getvalue('old'))
     into_item_id = int(form.getvalue('into'))
@@ -25,11 +25,11 @@ else:
 
     FROM = "item_notifications@openproduce.org"
     TO = ["info@openproduce.org"]
-    
+
     SUBJECT = 'Item merger notification'
-    
+
     TEXT = '''Item %s was merged into %s (%s). '%s' no longer exists in the database.''' % (old_item.id, into_item.id, into_item, old_item)
-    
+
     message = """\
 From: %s
 To: %s
@@ -37,7 +37,7 @@ Subject: %s
 
 %s
 """ % (FROM, ", ".join(TO), SUBJECT, TEXT)
-    
+
     # Send the mail
 
     server = smtplib.SMTP(SERVER)

--- a/web/staff/op_tools/move_kehe_ids.py
+++ b/web/staff/op_tools/move_kehe_ids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # catalog.py
 # Patrick McQuighan
 # An update script that takes distributor item ids from Kehe items and appends them to the item's notes section.
@@ -22,6 +22,4 @@ for p,item,d,dist_item in kehe_items:  # p and d are unused
     if len(barcodes) == 1:
         dist_item.set_dist_item_id(barcodes[0])
     else:
-        print 'Item %s has more than 1 barcode --> ambiguity, no action taken.' % (item)
-    
-    
+        print('Item %s has more than 1 barcode --> ambiguity, no action taken.' % (item))

--- a/web/staff/op_tools/op_db_library.py
+++ b/web/staff/op_tools/op_db_library.py
@@ -35,6 +35,7 @@ from sqlalchemy.orm import mapper
 from sqlalchemy.orm import relation, backref
 from sqlalchemy.orm import sessionmaker
 from decimal import Decimal, ROUND_HALF_EVEN
+from functools import reduce
 
 from db_config import register_tape_db_config, inventory_db_config
 

--- a/web/staff/op_tools/op_db_library.py
+++ b/web/staff/op_tools/op_db_library.py
@@ -828,7 +828,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
 
         date_key = day.date()
 
-        if not totals.has_key(date_key):
+        if date_key not in totals:
             totals[date_key] = {}
             totals[date_key]['total'] = 0
             for k,v in PAYMENT.iteritems():  # Have to initialize the each payment type for this day to be 0

--- a/web/staff/op_tools/op_db_library.py
+++ b/web/staff/op_tools/op_db_library.py
@@ -868,7 +868,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
 
         date_key = day.date()
 
-        if not tabs.has_key(date_key):
+        if date_key not in tabs:
             tabs[date_key] = {}
             for k,v in PAYMENT.items(): # Have to initialize the each payment type for this day to be 0
                 tabs[date_key][v] = 0
@@ -878,7 +878,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
         tabs[date_key][payment_name] += float(row[2])
 
         if payment_name == 'cash':          # record cash in
-            if not cash_in.has_key(date_key):
+            if date_key not in cash_in:
                 cash_in[date_key] = 0
             cash_in[date_key] += float(row[2])
 
@@ -903,7 +903,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
         date_key = day.date()
 
         if payment_name == 'cash':          # record cash in
-            if not cash_in.has_key(date_key):
+            if date_key not in cash_in:
                 cash_in[date_key] = 0
             cash_in[date_key] -= float(row[2])
 

--- a/web/staff/op_tools/op_db_library.py
+++ b/web/staff/op_tools/op_db_library.py
@@ -669,7 +669,7 @@ def get_daily_sales(start_date=FIRST_SALES, end_date=datetime.datetime.now()):
             if hour in range(0,DAY_START_HOUR):        # put hours midnight - start hour on previous day
                 date_key -= datetime.timedelta(days=1)
 
-            if days.has_key(date_key):  # have the day already
+            if date_key in days: # have the day already
                 info = days[date_key]
                 info.set_hour_sales(hour, float(result[1]), int(result[2]))
             else:   # day not currently there

--- a/web/staff/op_tools/op_db_library.py
+++ b/web/staff/op_tools/op_db_library.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # op_db_library.py
 # Patrick McQuighan
 # This is the central library for interacting with the OpenProduce databases, inventory and register_tape.
@@ -276,7 +276,7 @@ def remove_distributor(dist):
 def set_barcode_item_byid(bc_item_id, newbarcode):
     to_change = inv_session.query(BarcodeItem).filter(BarcodeItem.id == bc_item_id).one()
     to_change.barcode = newbarcode
-    inv_session.flush()    
+    inv_session.flush()
 
 def get_barcode_item(item,bc):
     return inv_session.query(BarcodeItem).filter(and_(BarcodeItem.item_id == item.id,BarcodeItem.barcode == bc)).one()
@@ -297,12 +297,12 @@ def get_distributor_item_margin(item, distributor,dist_item=None):
     each_cost = dist_item.get_each_cost()
     op_price = item.get_price()
     tax = item.get_tax_value()
-    
+
     if op_price - tax > 0:
         margin = (1.0 - each_cost/(op_price - tax)) * 100
     else:
         margin = 100
-        
+
     return margin
 
 def set_item_discontinued(item, val):
@@ -372,7 +372,7 @@ def remove_barcode_item_byid(bc_item_id):
 def remove_category_item_byid(cat_item_id):
     to_remove = inv_session.query(CategoryItem).filter(CategoryItem.id == cat_item_id).one()
     inv_session.delete(to_remove)
-    inv_session.flush()    
+    inv_session.flush()
 
 def remove_category_item(item,category):
     to_remove = inv_session.query(CategoryItem).filter(and_(CategoryItem.item_id == item.id, CategoryItem.cat_id == category.id)).one()
@@ -382,7 +382,7 @@ def remove_category_item(item,category):
 def remove_distributor_item_byid(dist_item_id):
     to_remove = inv_session.query(DistributorItem).filter(DistributorItem.id == dist_item_id).one()
     inv_session.delete(to_remove)
-    inv_session.flush()    
+    inv_session.flush()
 
 def remove_distributor_item(item,distributor):
     to_remove = inv_session.query(DistributorItem).filter(and_(DistributorItem.item_id == item.id, DistributorItem.dist_id == distributor.id)).one()
@@ -398,7 +398,7 @@ def get_items(hide_discontinued=False,show_categories=None,show_distributors=Non
     items = inv_session.query(Item)
     if hide_discontinued:
         items = items.filter(Item.is_discontinued == False)
-        
+
     if hide_categoryless:
         items = items.filter(Item.categories.any(Category.name.in_(show_categories)))
     else:
@@ -444,7 +444,7 @@ def get_distributor_items(hide_discontinued=False,show_categories=None,show_dist
     if hide_distributorless:
         items = items.filter(Item.distributors.any(Distributor.name.in_(show_distributors)))
     else:
-        items = items.filter(or_(Item.distributors.any(Distributor.name.in_(show_distributors)), Item.distributors == None))        
+        items = items.filter(or_(Item.distributors.any(Distributor.name.in_(show_distributors)), Item.distributors == None))
 
     return items.all()
 
@@ -459,12 +459,12 @@ def filter_valid_sales (query_obj, start_date=None, end_date=None, slushfund=Fal
                               not_(SaleItem.item_id.in_([TAB_PAYMENT, CASH_BACK]))))
     if (not slushfund):
         query_obj = query_obj.filter(or_(Sale.customer_id!=SLUSHFUND, Sale.customer_id == None))
-                              
+
     if (start_date != None):
         query_obj = query_obj.filter (Sale.time_ended > start_date)
     if (end_date != None):
         query_obj = query_obj.filter (Sale.time_ended < end_date)
-    
+
     return query_obj
 
 def get_sales_in_range(item_id, days):
@@ -498,7 +498,7 @@ def add_item_count(item_id, amount):
     item = inv_session.query(Item).filter(Item.id == item_id).one()
     if item != None:
         item.count += amount
-        
+
         inv_session.flush()
         return item.count
 
@@ -534,7 +534,7 @@ def merge_items(old_item, new_item, merge_barcodes, merge_deliveries, merge_dist
     inv_session.flush()
     inv_session.delete(old_item)
     inv_session.flush()
-    
+
 def get_item_history(item_id, days):
     '''returns a 4-tuple of:
     total_sales (in units, not slushfunded)
@@ -604,7 +604,7 @@ class DailySaleInfo(object):
 
     def get_date(self):
         return self.date
-    
+
     def get_dayname(self):
         if self.date != None:
             return self.date.strftime('%A')
@@ -612,13 +612,13 @@ class DailySaleInfo(object):
 
     def get_date_str(self):
         if self.date != None:
-            return self.date.strftime('%Y-%m-%d')            
+            return self.date.strftime('%Y-%m-%d')
         return ''
 
     def get_hourly_sales(self,hours):
         '''returns a list of HourlySaleInfo objects for the hours specified'''
         return [self.hours[i] for i in hours]
-    
+
     def set_hour_sales(self, hour, gross, customers):
         self.hours[hour].set_gross(gross)
         self.hours[hour].set_customers(customers)
@@ -639,10 +639,10 @@ class HourlySaleInfo(object):
 
     def get_customers(self):
         return self.customers
-    
+
     def get_gross_sales(self):
         return self.gross
-    
+
     def set_gross(self, gross):
         self.gross = gross
 
@@ -650,7 +650,7 @@ class HourlySaleInfo(object):
         self.customers = customers
 
 def get_daily_sales(start_date=FIRST_SALES, end_date=datetime.datetime.now()):
-    '''returns a list of DailySaleInfo objects.  This is used by hours.py and other scripts needing sale info on a daily/hourly basis. 
+    '''returns a list of DailySaleInfo objects.  This is used by hours.py and other scripts needing sale info on a daily/hourly basis.
     optionally takes a range of dates by start_date and end_date.
     '''
 
@@ -708,7 +708,7 @@ def get_sales_tax_report(start_date, end_date):
     negative_prices = map(to_id, inv_session.query(Price).filter(Price.unit_cost < 0.0).all())
     refund_items = inv_session.query(Item).filter(Item.price_id.in_(negative_prices)).all()
 
-    # Can make these dicts to improve speed if needed 
+    # Can make these dicts to improve speed if needed
     zero_rate_ids = map(to_id, zero_rate_items)
     food_rate_ids = map(to_id, food_rate_items)
     general_rate_ids = map(to_id, general_rate_items)
@@ -731,7 +731,7 @@ def get_sales_tax_report(start_date, end_date):
         if int(y[payment]) == LINK_PAYMENT:
             return x + float(y[cost])
         return x
-            
+
     def non_link (x,y):
         '''sim to link_only but only adds if y is NOT a link transaction'''
         if (int(y[payment]) != LINK_PAYMENT):
@@ -777,8 +777,8 @@ def get_sales_tax_report(start_date, end_date):
     refund_sales = -1.0 * reduce(refunds,sales,0)  # refund total is negative, so we flip the sign
     # refunds are already included in one of these groups of sales, so we have to add 2*refund_sales in order to
     # get the $ value of everything rung up at the store
-    #sales_dollars = link_sales + non_link_sales + 2*refund_sales 
-    sales_dollars = link_sales + non_link_sales + refund_sales 
+    #sales_dollars = link_sales + non_link_sales + 2*refund_sales
+    sales_dollars = link_sales + non_link_sales + refund_sales
     # removing the 2x -SL 5/18/12
 
     deductions = link_sales + food_tax + general_tax + orphan_tax + refund_sales + transit_sales
@@ -807,7 +807,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
     #else:
             #commented out because i don't understand it.  -SL 5/18/12
     sales = sales.group_by(func.date(Sale.time_ended)).group_by(func.hour(Sale.time_ended)).group_by(func.hour(Sale.time_ended))
-        
+
     totals = {}
     tabs = {}
     cash_in = {}
@@ -826,7 +826,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
             day = datetime.datetime(day.year, day.month, 1)
 
         date_key = day.date()
-            
+
         if not totals.has_key(date_key):
             totals[date_key] = {}
             totals[date_key]['total'] = 0
@@ -841,7 +841,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
             totals[date_key][payment_name] += float(row[2])
             if payment_name == 'cash':
                 cash_in[date_key] += float(row[2])
-                
+
             totals[date_key]['total'] += float(row[2])
         else:                                   # otherwise don't include tax when adding
             totals[date_key][payment_name] += float(row[1])
@@ -866,7 +866,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
             day -= datetime.timedelta(days=day.day-1)
 
         date_key = day.date()
-            
+
         if not tabs.has_key(date_key):
             tabs[date_key] = {}
             for k,v in PAYMENT.iteritems():  # Have to initialize the each payment type for this day to be 0
@@ -875,7 +875,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
         payment_type = int(row[3])
         payment_name = PAYMENT[payment_type]
         tabs[date_key][payment_name] += float(row[2])
-        
+
         if payment_name == 'cash':          # record cash in
             if not cash_in.has_key(date_key):
                 cash_in[date_key] = 0
@@ -908,20 +908,20 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
 
 
     return [totals,tabs,cash_in]
-    
+
 
 #####################################################
-# 
+#
 # Classes for interacting with inventory database
 #
 # Note: the classes that have data imported from marzipan
 #  have an optional paramter id in the constructor.
-#  This is because I wanted to make sure that the ids from the old 
+#  This is because I wanted to make sure that the ids from the old
 #  database are exactly the same as the ones in the new database
-#  if this is ignored then it will be auto-incremented from whatever 
-#  the previous value was.  
+#  if this is ignored then it will be auto-incremented from whatever
+#  the previous value was.
 #  Classes that are new do not have this as the id should
-#  not be set manually.  
+#  not be set manually.
 #  This also holds for classes for register_tape
 #
 #  Additionally note that the names for variables in the classes
@@ -952,12 +952,12 @@ class Item(object):
     def __repr__(self):
         return "<Item('%s','%s',%s,%d)>"%(
             self.name, self.plu,
-            str(self.size), 
+            str(self.size),
             self.is_discontinued)
 
     def __str__(self):
         if self.size_unit_id != None:
-            return "%s [%.2f %s]" % (self.name, self.size, units_dict[self.size_unit_id]) 
+            return "%s [%.2f %s]" % (self.name, self.size, units_dict[self.size_unit_id])
         else:
             return "%s []" % self.name
 
@@ -966,10 +966,10 @@ class Item(object):
 
     def get_id(self):
         return self.id
-    
+
     def get_name(self):
         return self.name
-    
+
     def get_price(self):
         return float(inv_session.query(Price.unit_cost).filter(Price.id == self.price_id).one()[0])
 
@@ -1014,13 +1014,13 @@ class Item(object):
         distributors = inv_session.query(DistributorItem.dist_id).filter(DistributorItem.item_id == self.id).all()
         dist_list = [str(d[0]) for d in distributors]
         return ','.join(dist_list)
-        
+
     def get_barcodes(self):
         return inv_session.query(BarcodeItem).filter(BarcodeItem.item_id == self.id).all()
 
     def get_unit_size(self):
         return self.size
-    
+
     def get_size_unit_id(self):
         return self.size_unit_id
 
@@ -1045,7 +1045,7 @@ class Item(object):
     def get_barcodes_str(self):
         barcodes = self.get_barcodes()
         return ','.join(map(BarcodeItem.get_barcode, barcodes))
-        
+
     def get_category_items(self):
         c_items = inv_session.query(CategoryItem).filter(CategoryItem.item_id == self.id).all()
         return c_items
@@ -1081,7 +1081,7 @@ class Item(object):
         if self.notes == None:
             return ''
         return self.notes
-    
+
     def set_notes(self, new_notes):
         self.notes = new_notes
         inv_session.flush()
@@ -1135,10 +1135,10 @@ class SaleUnit(object):
 
     def get_id(self):
         return self.id
-    
+
     def get_time_ended(self):
         return self.get_time_ended
-    
+
     def get_name(self):
         return self.name
 
@@ -1189,7 +1189,7 @@ class Delivery(object):
         self.dist_id = dist_id
         if id != None:
             self.id = id
-    
+
     def get_time_delivered(self):
         return self.time_delivered
 
@@ -1202,7 +1202,7 @@ class Category(object):
         self.name = name
         if id != None:   # otherwise will auto-increment
             self.id = id
-    
+
     def get_name(self):
         return self.name
 
@@ -1218,7 +1218,7 @@ class CategoryItem(object):
     def __init__(self, item_id, cat_id):
         self.item_id = item_id
         self.cat_id = cat_id
-    
+
     def get_id(self):
         return self.id
 
@@ -1267,10 +1267,10 @@ class DistributorItem(object):
         self.case_unit_id = case_unit_id
         if id != None:
             self.id = id
-    
+
     def __str__(self):
         return '%s. Dist Item ID: %s. Case: $%.2f for %.2f %s.' % (dist_dict[self.dist_id], self.dist_item_id, self.wholesale_price, self.case_size, units_dict[self.case_unit_id])
-        
+
     def get_item_id(self):
         return self.item_id
 
@@ -1374,13 +1374,13 @@ class SaleItem(object):
         self.quantity = quantity
         self.unit_cost = unit_cost
         self.cost = cost
-        self.tax = tax 
+        self.tax = tax
         self.total = total
         self.is_refund = is_refund
-       
+
     def __str__(self):
         return '%d, %.2f' %(self.item_id,self.quantity)
- 
+
     def get_unit_cost(self):
         return self.unit_cost
 
@@ -1432,7 +1432,7 @@ class ItemCountLog(object):
         if self.old_count != None:
             return self.new_count - self.old_count
         return self.new_count
-    
+
     def get_is_manual_count(self):
         return self.is_manual_count
 
@@ -1538,7 +1538,7 @@ sale_units = Table('sale_units', inv_md,
 
 price_changes = Table('price_changes', inv_md,
                       Column('id',Integer, primary_key=True),
-                      Column('old_price_id',Integer, nullable=False), 
+                      Column('old_price_id',Integer, nullable=False),
                       Column('new_price_id',Integer, nullable=False),
                       Column('special_id',Integer, ForeignKey('specials.id'))
                       )
@@ -1602,7 +1602,7 @@ barcode_items = Table('barcode_items', inv_md,
                       Column('barcode', String(16))
                       )
 
-item_count_log = Table('item_count_log', inv_md, 
+item_count_log = Table('item_count_log', inv_md,
                        Column('id', Integer, primary_key=True),
                        Column('item_id',Integer,ForeignKey('items.id'),nullable=False),
                        Column('old_count', Integer,default=None),
@@ -1612,17 +1612,17 @@ item_count_log = Table('item_count_log', inv_md,
                        )
 
 # map classes to the tables defined above
-mapper(Item, items, properties = {'categories' : 
-                                  relation(Category,secondary=category_items, 
+mapper(Item, items, properties = {'categories' :
+                                  relation(Category,secondary=category_items,
                                            primaryjoin=items.c.id==category_items.c.item_id,
                                            secondaryjoin=category_items.c.cat_id==categories.c.id,
                                            foreign_keys=[category_items.c.item_id,category_items.c.cat_id]),
-                                  'distributors' : 
+                                  'distributors' :
                                   relation(Distributor, secondary=distributor_items,
                                            primaryjoin=items.c.id==distributor_items.c.item_id,
                                            secondaryjoin=distributor_items.c.dist_id==distributors.c.id,
                                            foreign_keys=[distributor_items.c.item_id,distributor_items.c.dist_id])
-                                            
+
 })
 mapper(ItemCountLog, item_count_log)
 mapper(Price, prices)

--- a/web/staff/op_tools/op_db_library.py
+++ b/web/staff/op_tools/op_db_library.py
@@ -696,10 +696,11 @@ def get_sales_tax_report(start_date, end_date):
     # get items that are sold under high and low tax rates
     taxcats = get_tax_categories ()
 
-    zero_rate = map(to_id,filter (lambda x: x.get_rate() == .0000, taxcats))
-    food_rate = map(to_id,filter (lambda x: x.get_rate() == .0225, taxcats))
-    general_rate = map(to_id,filter (lambda x: x.get_rate() > .0225, taxcats))
-    soft_drink_rate = map(to_id, filter (lambda x: x.get_name() == 'soda', taxcats))
+    # map() returns a map object in python3, but we're expecting lists
+    zero_rate = list(map(to_id,filter (lambda x: x.get_rate() == .0000, taxcats)))
+    food_rate = list(map(to_id,filter (lambda x: x.get_rate() == .0225, taxcats)))
+    general_rate = list(map(to_id,filter (lambda x: x.get_rate() > .0225, taxcats)))
+    soft_drink_rate = list(map(to_id, filter (lambda x: x.get_name() == 'soda', taxcats)))
 
     zero_rate_items = inv_session.query(Item).filter(Item.tax_category_id.in_(zero_rate)).all()
     food_rate_items = inv_session.query(Item).filter(Item.tax_category_id.in_(food_rate)).all()
@@ -710,10 +711,10 @@ def get_sales_tax_report(start_date, end_date):
     refund_items = inv_session.query(Item).filter(Item.price_id.in_(negative_prices)).all()
 
     # Can make these dicts to improve speed if needed
-    zero_rate_ids = map(to_id, zero_rate_items)
-    food_rate_ids = map(to_id, food_rate_items)
-    general_rate_ids = map(to_id, general_rate_items)
-    soft_drink_rate_ids = map(to_id, soft_drink_rate_items)
+    zero_rate_ids = list(map(to_id, zero_rate_items))
+    food_rate_ids = list(map(to_id, food_rate_items))
+    general_rate_ids = list(map(to_id, general_rate_items))
+    soft_drink_rate_ids = list(map(to_id, soft_drink_rate_items))
 
     # there are some sales where the item has been deleted or doesn't have a tax_category_id or something...in this case assume 2.25%
     # -SL 5/18/12
@@ -724,7 +725,7 @@ def get_sales_tax_report(start_date, end_date):
       except:
         pass
 
-    refund_item_ids = map(to_id, refund_items)
+    refund_item_ids = list(map(to_id, refund_items))
 
     def link_only (x,y):
         '''returns the sum where x = cost and y = (cost,total,payment) if y is a LINK transaction.
@@ -1003,7 +1004,7 @@ class Item(object):
         return inv_session.query(DistributorItem).filter(DistributorItem.item_id == self.id).all()
 
     def get_distributors_str(self):
-        distributors = map(str,[dist_dict[di.dist_id] for di in self.get_distributors()])  # convert between the distributor item to distributor then apply str to all of them
+        distributors = list(map(str,[dist_dict[di.dist_id] for di in self.get_distributors()]))  # convert between the distributor item to distributor then apply str to all of them
         distributors.sort()
         return ','.join(distributors)
 
@@ -1055,7 +1056,7 @@ class Item(object):
         return inv_session.query(Category).filter(and_(Category.id == CategoryItem.cat_id, CategoryItem.item_id == self.id)).all()
 
     def get_categories_str(self):
-        categories = map(str,self.get_categories())
+        categories = list(map(str,self.get_categories()))
         categories.sort()
         return ','.join(categories)
 

--- a/web/staff/op_tools/op_db_library.py
+++ b/web/staff/op_tools/op_db_library.py
@@ -831,7 +831,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
         if date_key not in totals:
             totals[date_key] = {}
             totals[date_key]['total'] = 0
-            for k,v in PAYMENT.iteritems():  # Have to initialize the each payment type for this day to be 0
+            for k, v in PAYMENT.items(): # Have to initialize the each payment type for this day to be 0
                 totals[date_key][v] = 0
             cash_in[date_key] = 0            # if it's not in the totals dict then it's also not in the cash_in dict
 
@@ -870,7 +870,7 @@ def get_accounts(order_type, start_date=FIRST_SALES,end_date=datetime.datetime.n
 
         if not tabs.has_key(date_key):
             tabs[date_key] = {}
-            for k,v in PAYMENT.iteritems():  # Have to initialize the each payment type for this day to be 0
+            for k,v in PAYMENT.items(): # Have to initialize the each payment type for this day to be 0
                 tabs[date_key][v] = 0
 
         payment_type = int(row[3])

--- a/web/staff/op_tools/sales_graph.py
+++ b/web/staff/op_tools/sales_graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # sales_graph.py
 # Patrick McQuighan
 # Displays a png graph with sales between 9am-11pm, 11pm-midnight, midnight-4am
@@ -49,7 +49,7 @@ def make_graph(dates, vals, name):
     # Make sure we don't have negative values on the y-axis
     ymin,ymax = ax.get_ylim()
     ax.set_ylim(0,ymax)
-    
+
     ax.set_title(name)
     ax.grid(True)
     ax.legend(loc=0,ncol=2,prop=FontProperties(size='small'))
@@ -63,15 +63,15 @@ def find_index(hour):
             return i
 
 def get_values(value_type):
-    '''Returns a list containing 1 list for each hour range.  Each inner list contains a 14-day moving average of 
+    '''Returns a list containing 1 list for each hour range.  Each inner list contains a 14-day moving average of
     values for each day since store opening'''
-    hours = [9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,0,1,2,3]    
-    
+    hours = [9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,0,1,2,3]
+
     values = [[] for i in hour_idx_range]
     dates = []
 
     day_infos = db.get_daily_sales()
-    window_size = 14   # number of days to use in running avg 
+    window_size = 14   # number of days to use in running avg
     running_avgs = [[0.0 for w in range(window_size)] for i in hour_idx_range]   # indexed by hour-range-index then 0 to window_size-1
     window_idx = 0
     for i,key in enumerate(sorted(day_infos.keys())):   # go through days in order
@@ -79,7 +79,7 @@ def get_values(value_type):
         daily_sales =  day_info.get_gross_sales()
 
         dates.append(day_info.get_date())
-        
+
         hourly_sales = [0.0 for h in hour_idx_range]
 
         for hour_info in day_info.get_hourly_sales(hours):
@@ -101,7 +101,7 @@ def get_values(value_type):
 
         for idx,val in enumerate(to_append):
             values[idx].append(val)
-        
+
     return dates,values
 
 def accumulate(values):
@@ -116,7 +116,7 @@ def accumulate(values):
     return acc
 
 def main():
-    print 'Content-Type: image/png\n'
+    print('Content-Type: image/png\n')
     form = cgi.FieldStorage()
     graph = form.getvalue('graph')
     dates,vals = get_values (graph)

--- a/web/staff/op_tools/sales_graph.py
+++ b/web/staff/op_tools/sales_graph.py
@@ -54,7 +54,7 @@ def make_graph(dates, vals, name):
     ax.grid(True)
     ax.legend(loc=0,ncol=2,prop=FontProperties(size='small'))
     g.autofmt_xdate()
-    g.savefig(sys.stdout, format='png')
+    g.savefig(sys.stdout.buffer, format='png')
 
 def find_index(hour):
     '''Given an hour, finds which range it belongs to'''

--- a/web/staff/op_tools/sales_tax.py
+++ b/web/staff/op_tools/sales_tax.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Computes the following for a given range of dates:
 
 import op_db_library as db
 import datetime
 
 
-print '''Content-type: text/html\n
+print('''Content-type: text/html\n
 <html>
 <head>
 <style type="text/css">
@@ -14,41 +14,41 @@ print '''Content-type: text/html\n
 </style>
 <title>OP Sales Tax Report</title>
 </head>
-<body>'''
+<body>''')
 
 def print_the_stuff(start_date, end_date):
 
-	normal_report,soft_drink_report = db.get_sales_tax_report(start_date, end_date)
-	
-	format = '%m/%d/%y'
-	
-        print '''<hr/>'''
-	print '''<h2>Results are for sales between %s and %s</h2> <p />''' % (start_date.strftime(format), end_date.strftime(format))
-	
-	print '''<b>Normal Sales Tax (ST-1): </b> <br />'''
-	print '''Line 1: Total receipts <u>$%.2f</u><br />''' % (normal_report['total'])
-	print '''Line 2: Deductions <u>$%.2f</u><br />''' % (normal_report['deductions'])
-	print '''&nbsp; 1: General retail tax <u>$%.2f</u><br />''' % (normal_report['general_tax'])
-	print '''&nbsp; 2: food retail tax <u>$%.2f</u><br />''' % (normal_report['food_tax'] + normal_report['orphan_tax']) #assume unknown items are food rate
-	print '''&nbsp; 9: LINK <u>$%.2f</u><br />''' % (normal_report['link'])
-	print '''&nbsp; 15: refunds + transit cards $%.2f + $%.2f = <u>$%.2f</u><br />''' % (normal_report['refunds'], normal_report['transit'], normal_report['refunds'] + normal_report['transit'])
-	print '''Line 3 = 1 - 2 = <u>$%.2f</u> <br />''' % (round(normal_report['total'])-round(normal_report['deductions']))
-	print '''Line 4a: general sales <u>$%.2f</u><br />''' % (normal_report['general_sales'])
-	print '''Line 5a: food sales <u>$%.2f</u><br />''' % (normal_report['food_sales'] + normal_report['orphan_sales'])
-	print '''Line 8a: other  <u>$%.2f</u><br />''' % (normal_report['other_sales'])
-	line3 = round(normal_report['total'])-round(normal_report['deductions'])
-	four_to_eight = round(normal_report['general_sales'])+round(normal_report['other_sales'])+round(normal_report['food_sales'] + round(normal_report['orphan_sales']))
-	print '''Line 3 = 4a + 5a + 8a --> %.2f == %.2f? %s<br />'''  % ( line3, four_to_eight, int(line3) == int(four_to_eight))
-	
-	print '''<p>'''
-	print '''<b>Chicago Soft Drink tax:</b><br />'''
-	print '''Line 1: Total Chicago soft drinks receipts <u>$%.2f</u><br />''' % (soft_drink_report['total'])
-	print '''Line 2: Deductions <u>$%.2f</u><br />''' % (soft_drink_report['deductions'])
-	print '''Line 3: Taxable receipts <u>$%.2f</u><br />''' % (soft_drink_report['taxable'])
-	print '''Line 4: Tax due <u>$%.2f</u><br />''' % (soft_drink_report['taxdue'])
-	print '''Line 5: Discount <u>$%.2f</u><br />''' % (soft_drink_report['discount'])
-	print '''Line 6: Payment <u>$%.2f</u> <br />''' % (soft_drink_report['payment'])
-	print '''</body>\n</html>'''
+    normal_report,soft_drink_report = db.get_sales_tax_report(start_date, end_date)
+
+    format = '%m/%d/%y'
+
+    print('''<hr />''')
+    print('''<h2>Results are for sales between %s and %s</h2> <p />''' % (start_date.strftime(format), end_date.strftime(format)))
+
+    print('''<b>Normal Sales Tax (ST-1): </b> <br />''')
+    print('''Line 1: Total receipts <u>$%.2f</u><br />''' % (normal_report['total']))
+    print('''Line 2: Deductions <u>$%.2f</u><br />''' % (normal_report['deductions']))
+    print('''&nbsp; 1: General retail tax <u>$%.2f</u><br />''' % (normal_report['general_tax']))
+    print('''&nbsp; 2: food retail tax <u>$%.2f</u><br />''' % (normal_report['food_tax'] + normal_report['orphan_tax'])) #assume unknown items are food rate
+    print('''&nbsp; 9: LINK <u>$%.2f</u><br />''' % (normal_report['link']))
+    print('''&nbsp; 15: refunds + transit cards $%.2f + $%.2f = <u>$%.2f</u><br />''' % (normal_report['refunds'], normal_report['transit'], normal_report['refunds'] + normal_report['transit']))
+    print('''Line 3 = 1 - 2 = <u>$%.2f</u> <br />''' % (round(normal_report['total'])-round(normal_report['deductions'])))
+    print('''Line 4a: general sales <u>$%.2f</u><br />''' % (normal_report['general_sales']))
+    print('''Line 5a: food sales <u>$%.2f</u><br />''' % (normal_report['food_sales'] + normal_report['orphan_sales']))
+    print('''Line 8a: other  <u>$%.2f</u><br />''' % (normal_report['other_sales']))
+    line3 = round(normal_report['total'])-round(normal_report['deductions'])
+    four_to_eight = round(normal_report['general_sales'])+round(normal_report['other_sales'])+round(normal_report['food_sales'] + round(normal_report['orphan_sales']))
+    print('''Line 3 = 4a + 5a + 8a --> %.2f == %.2f? %s<br />'''  % ( line3, four_to_eight, int(line3) == int(four_to_eight)))
+
+    print('''<p>''')
+    print('''<b>Chicago Soft Drink tax:</b><br />''')
+    print('''Line 1: Total Chicago soft drinks receipts <u>$%.2f</u><br />''' % (soft_drink_report['total']))
+    print('''Line 2: Deductions <u>$%.2f</u><br />''' % (soft_drink_report['deductions']))
+    print('''Line 3: Taxable receipts <u>$%.2f</u><br />''' % (soft_drink_report['taxable']))
+    print('''Line 4: Tax due <u>$%.2f</u><br />''' % (soft_drink_report['taxdue']))
+    print('''Line 5: Discount <u>$%.2f</u><br />''' % (soft_drink_report['discount']))
+    print('''Line 6: Payment <u>$%.2f</u> <br />''' % (soft_drink_report['payment']))
+    print('''</body>\n</html>''')
 
 print_the_stuff(datetime.datetime (2016,1,1), datetime.datetime (2016,2,1))
 print_the_stuff(datetime.datetime (2016,2,1), datetime.datetime (2016,3,1))

--- a/web/staff/op_tools/update_barcode_item.py
+++ b/web/staff/op_tools/update_barcode_item.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # update_barcode_item.py
 # Starting using exceptions so that any error will be caught.  Eg
 # if there is some undetected error in the database, the user will
@@ -9,11 +9,11 @@ import cgi,sys
 import op_db_library as db
 
 def log_exception(*args):
-    print 'Error: %s' % (args[1],)
+    print('Error: %s' % (args[1],))
 
 sys.excepthook = log_exception
 
-print 'Content-Type: text/plain\n'
+print('Content-Type: text/plain\n')
 form = cgi.FieldStorage()
 action = form.getvalue("action")
 if action == 'add':
@@ -23,7 +23,7 @@ if action == 'add':
         barcode = form.getvalue("barcode")
         db.add_barcode_item(itemid, barcode)
         new_bcitem = db.get_barcode_item(item, barcode)
-        print new_bcitem.get_id()
+        print(new_bcitem.get_id())
     else:
         raise Exception ('missing either item_id or barcode. given:%s' % (form.keys()))
 elif action == 'remove':
@@ -33,6 +33,3 @@ elif action == 'remove':
         raise Exception ('bc_item_id not given')
 else:
     raise Exception('invalid action')
-
-
-

--- a/web/staff/op_tools/update_categories.py
+++ b/web/staff/op_tools/update_categories.py
@@ -1,15 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import cgi, sys
 import op_db_library as db
 
 def log_exception(*args):
-    print 'Error: %s' % (args[1],)
+    print('Error: %s' % (args[1],))
 
 sys.excepthook = log_exception
 
 form = cgi.FieldStorage()
-print 'Content-type: text/plain\n'
+print('Content-type: text/plain\n')
 action = form.getvalue('action')
 if action == 'add':
     if 'cat' in form:
@@ -19,7 +19,7 @@ if action == 'add':
         else:
             db.add_category(catname)
             cat = db.get_category_byname(catname)
-            print '%d,%s' % (cat.get_id(), cat.get_name())
+            print('%d,%s' % (cat.get_id(), cat.get_name()))
     else:
         raise Exception('no name given to add')
 elif action == 'remove':
@@ -29,18 +29,17 @@ elif action == 'remove':
     else:
         cat = db.get_category(catid)
         db.remove_category(cat)
-        print ''
+        print('')
 elif action == 'query':
     cat_list = [cat.get_name() for cat in db.get_categories()]
-    print ','.join(cat_list)
+    print(','.join(cat_list))
 elif action == 'query-name':
     cat_list = [str(cat.get_id())+','+cat.get_name() for cat in db.get_categories()]
-    print '\n'.join(cat_list)
+    print('\n'.join(cat_list))
 elif action == 'query-cat-id':
     if 'catname' in form:
         catname = form.getvalue('catname').strip()
         cat = db.get_category_byname(catname)
-        print '%d,%s' % (cat.get_id(), cat.get_name())
+        print('%d,%s' % (cat.get_id(), cat.get_name()))
 else:
     raise Exception ('invalid action')
-    

--- a/web/staff/op_tools/update_category_item.py
+++ b/web/staff/op_tools/update_category_item.py
@@ -1,15 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import cgi,sys
 import op_db_library as db
 
 def log_exception(*args):
-    print 'Error: %s' % (args[1],)
+    print('Error: %s' % (args[1],))
 
 sys.excepthook = log_exception
 
 form = cgi.FieldStorage()
-print 'Content-type: text/plain\n'
+print('Content-type: text/plain\n')
 action = form.getvalue('action')
 if action == 'add':
     if 'item_id' in form and 'cat_id' in form:
@@ -22,7 +22,7 @@ if action == 'add':
         else:
             db.add_category_item(item,cat)
             new_cat_item_id = db.get_category_item(item.get_id(),cat.get_id()).get_id()
-            print '%d,%s,%s' % (new_cat_item_id, db.get_category_info_page_link(catid),cat)
+            print('%d,%s,%s' % (new_cat_item_id, db.get_category_info_page_link(catid),cat))
     else:
         raise Exception ('need item_id and cat_id, given: %s ' % form.keys())
 elif action == 'remove':
@@ -41,7 +41,7 @@ elif action != None:
     itemid = int(form.getvalue('item'))
     if action == 'query':                       # get a list of all category for a given item
         item = db.get_item(itemid)
-        print item.get_categories_str()
+        print(item.get_categories_str())
     elif 'catid' in form or 'catname' in form:
         if 'catid' in form:
             catid = int(form.getvalue('catid'))
@@ -49,13 +49,13 @@ elif action != None:
         else:
             catname = form.getvalue('catname')
             cat = db.get_category_byname(catname)
-        item = db.get_item(itemid)        
+        item = db.get_item(itemid)
         if action == 'remove_item_cat':                        # delete category item
             if not db.is_category_item(item,cat):
                 raise Exception ('%s is not currently a category for %s' % (cat, item))
             else:
                 db.remove_category_item(item,cat)
-                print item.get_distributors_str()
+                print(item.get_distributors_str())
     else:
         raise Exception ('need a catid or catname')
 else:

--- a/web/staff/op_tools/update_distributor_item.py
+++ b/web/staff/op_tools/update_distributor_item.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # updates the distributors for a given item.
 # is passed in an itemid, distributor name and an action which is either 'add' or 'remove'
 # it prints out either 'Error: ....' or a comma separated string of the items updated distributors
@@ -8,12 +8,12 @@ import cgi,sys
 import op_db_library as db
 
 def log_exception(*args):
-    print 'Error: %s' % (args[1],)
+    print('Error: %s' % (args[1],))
 
 sys.excepthook = log_exception
 
 form = cgi.FieldStorage()
-print 'Content-type: text/plain\n'
+print('Content-type: text/plain\n')
 
 action = form.getvalue('action')
 if action == 'update_byid':    # temporary hack until things get sorted out with item_info (should only need this)
@@ -33,7 +33,7 @@ if action == 'update_byid':    # temporary hack until things get sorted out with
         if 'caseunit' in form:
             case_unit_id = int(form.getvalue('caseunit'))
 
-        db.update_distributor_item(dist_item, dist_item_id, wholesale_price, case_size, case_unit_id)        
+        db.update_distributor_item(dist_item, dist_item_id, wholesale_price, case_size, case_unit_id)
     else:
         raise Exception ('no distributor_item id given')
 elif action == 'remove_byid':  # temporary hack until things get sorted out with item_info (should only need this)
@@ -48,17 +48,17 @@ elif action == 'query-margin':  # temporary hack until things get sorted out wit
         item = db.get_item(dist_item.get_item_id())
         dist = db.get_distributor(dist_item.get_dist_id())
         margin = db.get_distributor_item_margin(item,dist,dist_item)
-        print '%.2f, %d' % (each_cost, margin)
+        print('%.2f, %d' % (each_cost, margin))
     else:
         raise Exception ('no distributor_item id given')
 elif 'item' in form:
     itemid = int(form.getvalue('item'))
     if action == 'query':                       # get a list of all distributors for a given item
         item = db.get_item(itemid)
-        print item.get_distributors_str()
+        print(item.get_distributors_str())
     elif action == 'query-id':    # get a string of all distributor ids for a given item
         item = db.get_item(itemid)
-        print item.get_distributor_ids_str()
+        print(item.get_distributor_ids_str())
     else:
         if 'distname' not in form and 'distid' not in form:
             raise Exception ('no distributor given')
@@ -69,22 +69,22 @@ elif 'item' in form:
             if 'distid' in form:
                 distid = int(form.getvalue('distid'))
                 dist = db.get_distributor(distid)
-            if dist == None: 
+            if dist == None:
                 raise Exception ('distributor not found in the database')
             else:
-                item = db.get_item(itemid)        
+                item = db.get_item(itemid)
                 if action == 'add':                        # add a new distributor item with the given distributor and item
                     added = db.add_distributor_item(item,dist)
                     if 'item_info' in form:   # temporary hack until things get totally sorted out with 'item_info' (should only need this)
-                        print added.get_id()
+                        print(added.get_id())
                     else:
-                        print item.get_distributors_str()
+                        print(item.get_distributors_str())
                 elif action == 'remove':                        # delete distributor item with given distributor name and item name
                     if not db.is_distributor_item(item,dist):
                         raise Exception ('%s is not currently a distributor for %s' % (dist, item))
                     else:
                         db.remove_distributor_item(item,dist)
-                        print item.get_distributors_str()
+                        print(item.get_distributors_str())
                 elif action == 'update':                              # update information (case size/units etc) for a distributor item
                     dist_item = db.get_distributor_item(item,dist)
                     dist_item_id = dist_item.get_dist_item_id()
@@ -99,7 +99,7 @@ elif 'item' in form:
                     if 'casesize' in form:
                         case_size = float(form.getvalue('casesize'))
                     if 'caseunit' in form:
-                        case_unit = form.getvalue('caseunit')            
+                        case_unit = form.getvalue('caseunit')
                         case_unit_id = db.get_unit_byname(case_unit).get_id()
 
                     db.update_distributor_item(dist_item, dist_item_id, wholesale_price, case_size, case_unit_id)

--- a/web/staff/op_tools/update_distributors.py
+++ b/web/staff/op_tools/update_distributors.py
@@ -1,15 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import cgi, sys
 import op_db_library as db
 
 def log_exception(*args):
-    print 'Error: %s' % (args[1],)
+    print('Error: %s' % (args[1],))
 
 sys.excepthook = log_exception
 
 form = cgi.FieldStorage()
-print 'Content-type: text/plain\n'
+print('Content-type: text/plain\n')
 action = form.getvalue('action')
 if action == 'add':
     if 'name' in form:
@@ -19,7 +19,7 @@ if action == 'add':
         else:
             db.add_distributor(distname)
             dist = db.get_distributor_byname(distname)
-            print '%d,%s' % (dist.get_id(),distname)
+            print('%d,%s' % (dist.get_id(),distname))
     else:
         raise Exception ('no distributor name given')
 elif action == 'remove':
@@ -28,14 +28,14 @@ elif action == 'remove':
         raise Exception ('distributor not in database')
     else:
         dist = db.get_distributor(distid)
-        print dist.get_name()
+        print(dist.get_name())
         db.remove_distributor(dist)
-        
+
 elif action == 'query':
     dist_list = [dist.get_name() for dist in db.get_distributors()]
-    print ','.join(dist_list)
+    print(','.join(dist_list))
 elif action == 'query-name':
     dist_list = [str(dist.get_id())+','+dist.get_name() for dist in db.get_distributors()]
-    print '\n'.join(dist_list);
+    print('\n'.join(dist_list));
 else:
     raise Exception ('invalid action')

--- a/web/staff/op_tools/update_item.py
+++ b/web/staff/op_tools/update_item.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Patrick McQuighan
 # update_item_count.py
 # this is a simple cgi interface that takes in an item id and a number and increases
@@ -9,12 +9,12 @@ import cgi,sys
 import op_db_library as db
 import datetime
 def log_exception(*args):
-    print 'Error: %s' % (args[1],)
+    print('Error: %s' % (args[1],))
 
 sys.excepthook = log_exception
 
 form = cgi.FieldStorage()
-print 'Content-type: text/plain\n'
+print('Content-type: text/plain\n')
 
 action = form.getvalue("action")
 if action == "count":
@@ -27,9 +27,9 @@ if action == "count":
             count = item.get_count()
             day14 = db.get_sales_in_range(int(form.getvalue("id")), 14)
             speculated = count - day14/14*days_to_speculate   # days_to_speculate determined outside of loop
-            print '%d,%d' % (speculated, count)
+            print('%d,%d' % (speculated, count))
         else:
-            print item.get_count()
+            print(item.get_count())
 elif action == "status":
     if "id" in form and "stocked" in form:
         item = db.get_item(int(form.getvalue("id")))
@@ -42,7 +42,7 @@ elif action == "delivery":
         itemid = int(form.getvalue("id"))
         db.add_delivery(itemid, int(form.getvalue("amt")), form.getvalue("dist"))
         item = db.get_item(itemid)
-        print "%d" % item.get_count()
+        print("%d" % item.get_count())
     else:
         raise Exception('invalid arguments')
 elif action == "name":
@@ -107,7 +107,7 @@ elif action == "add":
                 price_unit = None
 
         if not_valid:
-            print 'Error: invalid price'
+            print('Error: invalid price')
         else:
             count = int(form.getvalue('count'))
             plu = None
@@ -126,7 +126,7 @@ elif action == "add":
                     dist = db.get_distributor_byname(distname)
                     db.add_distributor_item(item, dist)
                     d_i = db.get_distributor_item(item, dist)
-                    
+
                     ditemid = 0
                     wholesale_price = 0
                     case_size = 0
@@ -157,14 +157,14 @@ elif action == "add":
                     for c_id in cat_ids:
                         cat = db.get_category(c_id)
                         db.add_category_item(item, cat)
-                print '%d,%d,%d,%.2f,%.2f,%.2f,%d,%.2f,%s,%s' % (itemid,item.get_price_id(), dist.get_id(), d_i.get_wholesale_price(),d_i.get_case_size(),each_cost,margin,cost,db.get_unit(item_price.get_sale_unit_id()), db.get_item_info_page_link(itemid))
-                
+                print('%d,%d,%d,%.2f,%.2f,%.2f,%d,%.2f,%s,%s' % (itemid,item.get_price_id(), dist.get_id(), d_i.get_wholesale_price(),d_i.get_case_size(),each_cost,margin,cost,db.get_unit(item_price.get_sale_unit_id()), db.get_item_info_page_link(itemid)))
+
     else:
         raise Exception ('incorrect arguments. given %s' % (form.keys()))
 elif action == 'get-string':
     if 'id' in form:
         item = db.get_item(int(form.getvalue("id")))
-        print item
+        print(item)
     else:
         raise Exception ('incorrect arguments. need id. given %s' % (form.keys()))
 elif action == 'get-margin':
@@ -172,13 +172,13 @@ elif action == 'get-margin':
         item = db.get_item(int(form.getvalue("item_id")))
         distributor = db.get_distributor(int(form.getvalue("dist_id")))
         margin = db.get_distributor_item_margin(item, distributor)
-        print margin
+        print(margin)
     else:
         raise Exception ('invlaid arguments. need item_id, distid. given %s' % (form.keys()))
 elif action == 'update-notes':
     if 'item_id' in form and 'notes' in form:
         item = db.get_item(int(form.getvalue("item_id")))
-        item.set_notes(form.getvalue('notes'))    
+        item.set_notes(form.getvalue('notes'))
     else:
         raise Exception ('invalid arguments. need item_id, notes. given %s' % (form.keys()))
 else:

--- a/web/staff/op_tools/update_prices.py
+++ b/web/staff/op_tools/update_prices.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Patrick McQuighan
 # update_prices.py
 # last mod: 1/28/2011
@@ -7,12 +7,12 @@ import cgi,sys
 import op_db_library as db
 
 def log_exception(*args):
-    print 'Error: %s' % (args[1],)
+    print('Error: %s' % (args[1],))
 
 sys.excepthook = log_exception
 
 form = cgi.FieldStorage()
-print 'Content-type: text/plain\n'
+print('Content-type: text/plain\n')
 
 action = form.getvalue("action")
 if action == 'price':
@@ -34,7 +34,7 @@ elif action == 'group':
                 db.set_item_price(item,newid)
                 price = db.get_price(newid)
                 sale_unit = db.get_unit(price.get_sale_unit_id())
-                print '%d,%d,%.2f,%d,%s' % (old,db.price_item_count(old),price.get_unit_cost(), price.get_id(),sale_unit) 
+                print('%d,%d,%.2f,%d,%s' % (old,db.price_item_count(old),price.get_unit_cost(), price.get_id(),sale_unit))
             else:
                 raise Exception ('price_id %d not currently in database' % (newid))
         else:
@@ -58,7 +58,7 @@ elif action == 'query':
             else:
                 margin = 100
             real_profit = op_price - each_cost - tax
-            print '%d,%d,%.2f,%.0f' % (item.get_id(), dist.get_id(), each_cost, margin)
+            print('%d,%d,%.2f,%.0f' % (item.get_id(), dist.get_id(), each_cost, margin))
     else:
         raise Exception ('invalid arguments. given %s' % (form.keys()))
 elif action == 'split':
@@ -72,7 +72,7 @@ elif action == 'split':
             newprice = db.add_new_price(oldprice)
             db.set_item_price(item,newprice.get_id())
             sale_unit = db.get_unit(newprice.get_sale_unit_id())
-            print '%d,%d,%.2f,%d,%s' % (old,db.price_item_count(old),newprice.get_unit_cost(), newprice.get_id(),sale_unit) 
+            print('%d,%d,%.2f,%d,%s' % (old,db.price_item_count(old),newprice.get_unit_cost(), newprice.get_id(),sale_unit))
         else:
             raise Exception ('invalid item_id')
     else:
@@ -87,9 +87,9 @@ elif action == 'item_price':
                 price = db.get_price(item.get_price_id())
                 db.set_price(price, float(form.getvalue("price")))
             else:
-                print 'Warning: changing this price will affect the following items:'
+                print('Warning: changing this price will affect the following items:')
                 for i in price_items:
-                    print '%s. SKU %d' % (i, i.get_id())
+                    print('%s. SKU %d' % (i, i.get_id()))
         else:
             raise Exception('invalid item_id')
     else:

--- a/web/staff/op_tools/update_tax_categories.py
+++ b/web/staff/op_tools/update_tax_categories.py
@@ -1,15 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import cgi,sys
 import op_db_library as db
 
 def log_exception(*args):
-    print 'Error: %s' % (args[1],)
+    print('Error: %s' % (args[1],))
 
 sys.excepthook = log_exception
 
 form = cgi.FieldStorage()
-print 'Content-type: text/plain\n'
+print('Content-type: text/plain\n')
 action = form.getvalue('action')
 if action == 'add':
     if 'taxcatname' in form and 'rate' in form:
@@ -20,9 +20,9 @@ if action == 'add':
         else:
             db.add_tax_category(taxcatname, rate)
             taxcat = db.get_tax_category_byname(taxcatname)
-            print '%d,%s' % (taxcat.get_id(),taxcatname)
+            print('%d,%s' % (taxcat.get_id(),taxcatname))
     else:
-                raise Exception ('invalid arguments. given %s' % (form.keys()))
+        raise Exception ('invalid arguments. given %s' % (form.keys()))
 elif action == 'remove':
     taxcatid = int(form.getvalue('taxcatid'))
     if not db.is_tax_category(taxcatid):
@@ -30,7 +30,7 @@ elif action == 'remove':
     else:
         taxcat = db.get_tax_category(taxcatid)
         db.remove_tax_category(taxcat)
-        print ''
+        print('')
 elif action == 'update':
     taxcatid = int(form.getvalue('taxcatid'))
     rate = float(form.getvalue('rate'))/ 100.0
@@ -39,14 +39,14 @@ elif action == 'update':
     else:
         taxcat = db.get_tax_category(taxcatid)
         db.update_tax_category(taxcat, rate)
-        print '%s' % str(taxcat)
+        print('%s' % str(taxcat))
 elif action == 'query':
     taxcat_list = [str(taxcat.get_id()) +','+str(taxcat) for taxcat in db.get_tax_categories()]
-    print ';'.join(taxcat_list)
+    print(';'.join(taxcat_list))
 elif action == 'query-item':
     itemid = int(form.getvalue('item_id'))
     item = db.get_item(itemid)
-    print item.get_tax_category()
+    print(item.get_tax_category())
 elif action == 'set-item':
     itemid = int(form.getvalue('item_id'))
     taxcatid = int(form.getvalue('taxcatid'))
@@ -54,4 +54,3 @@ elif action == 'set-item':
     item = db.get_item(itemid)
     taxcat = db.get_tax_category(taxcatid)
     db.update_item_tax_category(item, taxcat)
-


### PR DESCRIPTION
## Notes

* I changed the shebang on every file in /optools to ```/usr/bin/python3``` to work on my machine, but depending on how Python is configured in production, this may not be necessary.
* I switched off `only_full_group_by` SQL mode in my local MySQL DB: ```SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));``` as recommended in https://stackoverflow.com/questions/41887460/select-list-is-not-in-group-by-clause-and-contains-nonaggregated-column-inc. (I was getting an error of ```MySQLdb._exceptions.OperationalError: (1055, "Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'register_tape.sales.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")``` when loading a few files.)

## TODO

* When I search for an item in item_info.py, I get an error in the Apache log from item_graph.py when it tries to make a graph. The error is coming from a line in the Pillow module, so I'm not sure how to fix it. I fixed a similar error in sales_graph.py in [this commit](https://github.com/openproduce/marzipan/commit/964b57255716673449d3048356eba27e9f73b8a5), but that fix does not work in item_info.py. I'm not familiar enough with matplotlib or Pillow to debug further, unfortunately.
